### PR TITLE
Add dochost 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Contentful](https://contentful.com) `https://mcp.contentful.com/mcp`
   ⚡ 🔑 - Manage Contentful entries, assets, and content models.
+- [dochost](https://dochost.io/mcp) `https://dochost.io/api/mcp`
+  [![dochost MCP connector](https://glama.ai/mcp/connectors/io.dochost/dochost/badges/score.svg)](https://glama.ai/mcp/connectors/io.dochost/dochost)
+  ⚡ 🔐 - Publish Markdown or HTML as a hosted page and get a shareable link.
 - [Sanity](https://sanity.io) `https://mcp.sanity.io/mcp`
   [![Sanity MCP connector](https://glama.ai/mcp/connectors/io.sanity.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.sanity.www/mcp)
   ⚡ 🔐 - Query and mutate Sanity datasets and documents.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   ⚡ 🔑 - Manage Contentful entries, assets, and content models.
 - [dochost](https://dochost.io/mcp) `https://dochost.io/api/mcp`
   [![dochost MCP connector](https://glama.ai/mcp/connectors/io.dochost/dochost/badges/score.svg)](https://glama.ai/mcp/connectors/io.dochost/dochost)
-  ⚡ 🔐 - Publish Markdown or HTML as a hosted page and get a shareable link.
+  ⚡ 🔓 - Publish Markdown or HTML as a hosted page and get a shareable link.
 - [Sanity](https://sanity.io) `https://mcp.sanity.io/mcp`
   [![Sanity MCP connector](https://glama.ai/mcp/connectors/io.sanity.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.sanity.www/mcp)
   ⚡ 🔐 - Query and mutate Sanity datasets and documents.


### PR DESCRIPTION
Adds **dochost** to 📝 Content Management, moved over from awesome-mcp-servers#8036 (closed — dochost is a hosted service, not a GitHub-distributed server, so it belongs here).

dochost turns whatever an assistant just wrote into a public page: hand it Markdown or HTML and it returns a shareable link. No copy-paste, no repo, no deploy step.

- Homepage/docs: https://dochost.io/mcp
- Endpoint: `https://dochost.io/api/mcp`

Checks against CONTRIBUTING:

- **Reachable at a public URL** — `initialize` and `tools/list` answer anonymously (6 tools); `tools/call` returns 401 with `WWW-Authenticate: Bearer resource_metadata=...`, and `/.well-known/oauth-authorization-server` serves the metadata with dynamic client registration.
- **Usable by anyone** — public sign-up, free tier, single shared endpoint (no per-user URL).
- **Transport** — Streamable HTTP → ⚡
- **Auth** — OAuth → 🔐. No access marker: normal free-or-paid account.
- **Badge** — connector exists at `io.dochost/dochost`, currently rated A.

Placed alphabetically after Contentful.