### PR TITLE
Add Rootr to Knowledge & Memory 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   ⚡ 🔓 🆓 - Search models, datasets, and Spaces, and call Space APIs.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   ⚡ 🔐 - Read and write Notion pages, databases, and comments.
+- [Rootr](https://rootr.io) `https://rootr.io/mcp`
+  ⚡ 🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
 
 ### 🎯 <a name="marketing"></a>Marketing
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   ⚡ 🔐 - Read and write Notion pages, databases, and comments.
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
+  [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   ⚡ 🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
 
 ### 🎯 <a name="marketing"></a>Marketing


### PR DESCRIPTION
Adds **Rootr** to 🧠 Knowledge & Memory, after Notion.

Rootr is a hosted team workspace — documents, tables, spreadsheets, whiteboards, issue trackers, and CRM — that an AI client can read *and* write over MCP. Answers cite the exact document and paragraph they came from.

- Endpoint: `https://rootr.io/mcp` — Streamable HTTP
- Auth: OAuth 2.1 with dynamic client registration and PKCE. Unauthenticated requests get `401` plus `WWW-Authenticate: Bearer resource_metadata="https://rootr.io/.well-known/oauth-protected-resource"`, so clients discover the authorization server automatically.
- Public sign-up, free tier available — no per-user endpoint URL, the same URL works for everyone.
- Also listed in the official MCP Registry as `io.github.inspirio-co/rootr-cli`.

No Glama connector badge yet — the connector listing is in progress and I did not want to point the badge at something CI cannot resolve. Happy to add it in a follow-up.
