### PR TITLE
Add Human Design 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 
+- [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
+  [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
+  ⚡ 🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   ⚡ 🔓 🆓 - Ethiopian calendar and date conversion.


### PR DESCRIPTION
Adds **Human Design** to 🧰 Other Tools & Integrations, moved over from awesome-mcp-servers#7927 — [@punkpeye invited it here](https://github.com/punkpeye/awesome-mcp-servers/pull/7927#issuecomment-5580529740) because it is a hosted service rather than a GitHub-distributed server.

The tools compute Human Design bodygraphs from birth data (Swiss ephemeris positions, timezone-correct local birth clocks), keep a roster of saved people, compare two of them, and analyse a group.

- Homepage/docs: https://www.gethumandesign.com/mcp-docs/
- Endpoint: `https://api.gethumandesign.com/mcp`

Checks against CONTRIBUTING:

- **Reachable at a public URL** — an anonymous `initialize` returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://api.gethumandesign.com/.well-known/oauth-protected-resource"`, and that metadata plus `/.well-known/oauth-authorization-server` serve the OAuth discovery with dynamic client registration.
- **Usable by anyone** — public sign-up, free tier, one shared endpoint (no per-user URL).
- **Transport** — Streamable HTTP → ⚡
- **Auth** — OAuth → 🔐. No access marker: a normal free-or-paid account.
- **Badge** — connector exists at `com.gethumandesign.www/mcp`.
- Also listed in the official MCP registry as `com.gethumandesign.www/mcp`.

Placed alphabetically before Tseha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UrHDzLxJhruZUKFAPeKX7
