### PR TITLE
Add GoodBarber to Content Management 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Contentful](https://contentful.com) `https://mcp.contentful.com/mcp`
   ⚡ 🔑 - Manage Contentful entries, assets, and content models.
+- [GoodBarber](https://www.goodbarber.com/mcp/) `https://mcp.goodbarber.dev/mcp/sse`
+  [![GoodBarber MCP connector](https://glama.ai/mcp/connectors/dev.goodbarber/goodbarber-public-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.goodbarber/goodbarber-public-mcp)
+  ⚡ 🔐 - Manage a GoodBarber no-code app: content, push notifications, shop orders, members, and analytics.
 - [Sanity](https://sanity.io) `https://mcp.sanity.io/mcp`
   [![Sanity MCP connector](https://glama.ai/mcp/connectors/io.sanity.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.sanity.www/mcp)
   ⚡ 🔐 - Query and mutate Sanity datasets and documents.


### PR DESCRIPTION
**Server:** GoodBarber Public MCP, the hosted MCP server of GoodBarber (no-code mobile app builder)
**Endpoint:** `https://mcp.goodbarber.dev/mcp/sse`

- [x] The endpoint is public and answers an MCP `initialize` request (401 with `WWW-Authenticate: Bearer resource_metadata=...`, OAuth 2.1 with dynamic client registration)
- [x] Entry is in the correct category, in alphabetical order (Content Management, between Contentful and Sanity)
- [x] Transport and auth markers match what the endpoint actually does (Streamable HTTP, OAuth)

Official hosted MCP server for GoodBarber apps: any MCP client (Claude, ChatGPT, Codex, Cursor...) can manage an app's content, push notifications, shop orders, members and analytics after an OAuth sign-in. Public sign-up, no per-user URL.

Already listed on the official MCP Registry as `dev.goodbarber/goodbarber-public-mcp` and as a Glama connector (badge included).
Docs: https://www.goodbarber.com/mcp/
Server card: https://mcp.goodbarber.dev/.well-known/mcp/server-card.json

Follow-up to punkpeye/awesome-mcp-servers#5576, as suggested by @punkpeye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)