### PR TITLE
Add 1cent remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔎 <a name="search--data-extraction"></a>Search & Data Extraction
 
+- [1cent](https://1cent.maxzoa.ru) `https://1cent.maxzoa.ru/mcp`
+  [![1cent MCP connector](https://glama.ai/mcp/connectors/ru.maxzoa/1cent/badges/score.svg)](https://glama.ai/mcp/connectors/ru.maxzoa/1cent)
+  ⚡ 🔓 🆓 - Extract web content and metadata, discover site resources, and detect page changes, with free discovery tools and pay-per-call x402 USDC operations on Base.
 - [Bright Data](https://brightdata.com) `https://mcp.brightdata.com/mcp`
   ⚡ 🔐 💰 - Web scraping and SERP data through a managed proxy network.
 - [Cloudflare Radar](https://radar.cloudflare.com) `https://radar.mcp.cloudflare.com/mcp`


### PR DESCRIPTION
**Server:** 1cent — https://1cent.maxzoa.ru
**Endpoint:** https://1cent.maxzoa.ru/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Transport and auth markers match what the endpoint actually does

Adds 1cent to Search & Data Extraction, following the invitation to submit hosted services to this remote-only directory.

The endpoint uses Streamable HTTP. Initialize and tool discovery work anonymously, with no account or local process required. The no-account marker does not mean all operations are free: paid URL operations require per-call x402 USDC payments on Base, stated explicitly in the entry. There is no subscription or paywall on the MCP handshake.

The optional badge points to the existing Glama connector ru.maxzoa/1cent (ownership verified, grade A). Its cached evaluation lists 35 tools; the current public service exposes 43 paid and 3 free tools.

Validation: live initialize, tools/list, schemas and unpaid x402 requirement checks using the official Python MCP client; whitespace and three-line entry checks. No payment performed and no production changes.

Related submission: https://github.com/punkpeye/awesome-mcp-servers/pull/13895.
