### PR TITLE
Add turva.dev 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   ⚡ 🔓 🆓 - Ethiopian calendar and date conversion.
 - [turva.dev](https://turva.dev) `https://mcp.turva.dev/mcp`
+  [![turva.dev MCP connector](https://glama.ai/mcp/connectors/dev.turva/turva-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.turva/turva-mcp)
   ⚡ 🔓 🆓 - Read the turva.dev service catalog, pricing, agent-readiness score, and published security scan results.
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   ⚡ 🔓 🆓 - Ethiopian calendar and date conversion.
+- [turva.dev](https://turva.dev) `https://mcp.turva.dev/mcp`
+  ⚡ 🔓 🆓 - Read the turva.dev service catalog, pricing, agent-readiness score, and published security scan results.
 ## Community
 
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)


### PR DESCRIPTION
**Server:** turva.dev
**Endpoint:** `https://mcp.turva.dev/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Transport and auth markers match what the endpoint actually does

Four read-only tools: the service catalog and pricing, the agent-readiness score, the published web-security scan evidence, and the engagement principles behind the work. Streamable HTTP, no authentication, no account needed.

Opened after punkpeye/awesome-mcp-servers#9580, where this server was pointed to this list.