### PR TITLE
Add NuMetric — read-only accounting & ERP MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   ⚡ 🔓 🆓 - Historical return data for funds and tickers.
+- [NuMetric](https://numetric.work) `https://numetric-mcp.virifi.xyz/mcp`
+  [![NuMetric MCP connector](https://glama.ai/mcp/connectors/xyz.virifi.numetric-mcp/numetric/badges/score.svg)](https://glama.ai/mcp/connectors/xyz.virifi.numetric-mcp/numetric)
+  ⚡ 🔐 - Read-only queries over NuMetric accounting and ERP books: financial statements, KPIs, receivables and payables, invoices, and documents.
 - [Octagon](https://octagonagents.com) `https://mcp.octagonagents.com/mcp`
   [![Octagon MCP connector](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon/badges/score.svg)](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon)
   ⚡ 🔐 💰 - Private- and public-market financial research data.


### PR DESCRIPTION
**Server:** NuMetric — https://numetric.work
**Endpoint:** `https://numetric-mcp.virifi.xyz/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Transport and auth markers match what the endpoint actually does

Added under 💰 Finance, between Fruit Stand and Octagon.

First-party connector for the NuMetric.work accounting/ERP platform, operated by VIRIFI Technologies Ltd. Streamable HTTP with OAuth 2.1 + PKCE; NuMetric credentials never reach the client. Public sign-up with a free starter tier, multi-tenant.

Read-only by construction — there is no create, edit, delete, payment or transfer tool in the server. Every tool carries `readOnlyHint`, `destructiveHint: false` and `openWorldHint`, and each declares an `outputSchema`. The full tool surface is fetchable without connecting, at https://numetric-mcp.virifi.xyz/.well-known/mcp/server-card.json

Glama connector badge included: `xyz.virifi.numetric-mcp/numetric` (ownership verified).

Unauthenticated `initialize` answers `401` with `WWW-Authenticate: Bearer resource_metadata=…`, which is the spec-correct OAuth response — same shape as the Linear and Stripe entries already listed.

Also listed in the Official MCP Registry (`xyz.virifi.numetric-mcp/numetric`, v1.0.0), the Anthropic Connectors Directory, and Smithery (96/100).

Opened at your suggestion on punkpeye/awesome-mcp-servers#10740 — thanks for the pointer 🙌

🤖 Generated with [Claude Code](https://claude.com/claude-code)
