### PR TITLE
Add FTIR.fun remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Firecrawl](https://firecrawl.dev) `https://mcp.firecrawl.dev/v2/mcp`
   [![Firecrawl MCP connector](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp)
   ⚡ 🔓 🆓 - Crawl, scrape, and extract structured data from websites.
+- [FTIR.fun](https://ftir.fun) `https://ftir.fun/mcp`
+  [![FTIR.fun Spectral Search MCP connector – tool definition quality and endpoint health on Glama](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp)
+  ⚡ 🔑 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   ⚡ 🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   ⚡ 🔓 🆓 - Crawl, scrape, and extract structured data from websites.
 - [FTIR.fun](https://ftir.fun) `https://ftir.fun/mcp`
   [![FTIR.fun Spectral Search MCP connector – tool definition quality and endpoint health on Glama](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp)
-  ⚡ 🔑 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
+  ⚡ 🔐 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   ⚡ 🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`


### PR DESCRIPTION
**Server:** FTIR.fun
**Endpoint:** https://ftir.fun/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Transport and auth markers match what the endpoint actually does

FTIR.fun provides hosted FTIR spectrum analysis, spectral-library search, and peak and literature evidence over Streamable HTTP with bearer-token authentication. The Glama connector is claimed and its health badge is included.