### PR TITLE
Add gluten-free.fr (Search & Data Extraction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Firecrawl](https://firecrawl.dev) `https://mcp.firecrawl.dev/v2/mcp`
   [![Firecrawl MCP connector](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp)
   ⚡ 🔓 🆓 - Crawl, scrape, and extract structured data from websites.
+- [gluten-free.fr](https://gluten-free.fr) `https://gluten-free.fr/api/mcp`
+  ⚡ 🔓 🆓 - Verified gluten-free product catalogue and comparison data for the French market.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   ⚡ 🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`


### PR DESCRIPTION
Following your invitation on punkpeye/awesome-mcp-servers#9997 — this one has a hosted endpoint, so it belongs here rather than in the local-server list.

**Endpoint:** `https://gluten-free.fr/api/mcp`

Verified before submitting:

```
$ curl -s -X POST https://gluten-free.fr/api/mcp \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}'

{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",
 "capabilities":{"tools":{}},
 "serverInfo":{"name":"gluten-free-fr","version":"1.1.0"}}}
```

`tools/list` returns three tools: `search_products`, `get_product`, `list_comparatifs`.

**Markers:** ⚡ Streamable HTTP · 🔓 no authentication · 🆓 no account required.

**What it serves:** a catalogue of gluten-free products available in France, each with a verified retailer listing, plus eight structured category comparisons (pasta, flours, breads, biscuits, madeleines, legume pasta, breakfast cereals, pizza bases). Health and regulatory claims cite named French and European sources (SNFGE, HAS, AFDIAG, INSERM, EU regulation 828/2014).

Placed alphabetically in Search & Data Extraction — happy to move it elsewhere if you prefer a different section.