### PR TITLE
Add Kristo Intelligence — DeFi trading signals MCP server (x402 on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   ⚡ 🔓 🆓 - Historical return data for funds and tickers.
+- [Kristo Intelligence](https://kristo-intelligence-api.onrender.com) `https://kristo-intelligence-api.onrender.com/mcp`
+  ⚡ 🔓 💰 - DeFi trading signals and market intelligence for agents on Base; x402 pay-per-call in USDC, no signup.
 - [Octagon](https://octagonagents.com) `https://mcp.octagonagents.com/mcp`
   [![Octagon MCP connector](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon/badges/score.svg)](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon)
   ⚡ 🔐 💰 - Private- and public-market financial research data.


### PR DESCRIPTION
Adds a single entry to the 💰 Finance section (alphabetical, between Fruit Stand and Octagon).

- **Server:** Kristo Intelligence — DeFi trading signals and market intelligence for AI agents on Base (chain 8453).
- **Endpoint:** `https://kristo-intelligence-api.onrender.com/mcp` (Streamable HTTP; legacy SSE also available at `/mcp/sse`).
- **Tools:** market stats, on-chain sales history, bot/service status.
- **Auth:** none for connection — the endpoint answers MCP `initialize` anonymously.
- **Payments:** per-call x402 (USDC on Base), so the entry carries 💰; tools requiring data return a standard 402 challenge.
- **Markers:** ⚡ 🔓 💰
- No Glama connector badge yet — will be added in a follow-up once the connector listing is live.

One server, one entry, one commit. Happy to adjust wording or placement — thanks!
