### PR TITLE
Add Zip1 URL shortener 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   ⚡ 🔓 🆓 - Ethiopian calendar and date conversion.
+- [Zip1](https://zip1.io) `https://zip1.io/mcp`
+  ⚡ 🔓 🆓 - Shorten URLs with custom or emoji slugs, optional password and click limits, and read their click analytics.
 ## Community
 
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)


### PR DESCRIPTION
Moved over from https://github.com/punkpeye/awesome-mcp-servers/pull/1441 as suggested — Zip1 is a hosted endpoint, so it belongs on this list rather than the local one.

**Entry** (Other Tools & Integrations, alphabetical after Tseha):

```markdown
- [Zip1](https://zip1.io) `https://zip1.io/mcp`
  ⚡ 🔓 🆓 - Shorten URLs with custom or emoji slugs, optional password and click limits, and read their click analytics.
```

**Endpoint:** `https://zip1.io/mcp` — Streamable HTTP, no authentication, no account required. Verified with a live `initialize` handshake:

```
HTTP/2 200
{"id":1,"jsonrpc":"2.0","result":{"capabilities":{"tools":{}},"protocolVersion":"2024-11-05","serverInfo":{"name":"zip1-io-mcp","version":"1.0.0"}}}
```

**Tools:** `create_short_url`, `get_url_stats`, `validate_url`, `generate_short_code`.

No Glama connector yet — happy to add the badge in a follow-up once it is listed.