### PR TITLE
Add PartReel — KiCad parts registry for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [OpenRouter](https://openrouter.ai) `https://mcp.openrouter.ai/mcp`
   [![OpenRouter MCP connector](https://glama.ai/mcp/connectors/ai.openrouter.mcp/open-router/badges/score.svg)](https://glama.ai/mcp/connectors/ai.openrouter.mcp/open-router)
   ⚡ 🔐 - Look up OpenRouter model metadata and pricing, and run completions.
+- [PartReel](https://partreel.com) `https://mcp.partreel.com/mcp`
+  ⚡ 🔓 🆓 - Search and fetch verified KiCad parts (symbol, footprint, 3D model) for AI-assisted PCB design — 21k+ parts, CC-BY-4.0, no account needed. Beta: coverage varies by part; field reports welcome.
 - [Postman](https://postman.com) `https://mcp.postman.com/mcp`
   ⚡ 🔐 - Work with Postman collections, environments, and APIs.
 - [UI Verify](https://uiverify.ai) `https://uiverify.ai/api/mcp`


### PR DESCRIPTION
PartReel is a public registry of KiCad parts (symbol + footprint + 3D model) built for AI agents that design PCBs. The MCP server exposes search_parts / get_part and returns download URLs for the assets; everything is CC-BY-4.0.

- Endpoint: https://mcp.partreel.com/mcp (Streamable HTTP, no auth, no account)
- Homepage / agent guide: https://partreel.com/agents/
- Status: beta — 21k+ parts, verification status is shown per part; problems can be reported via the field-report issue template in the repo.

Follow-up to punkpeye/awesome-mcp-servers#9156 (closed; this server is remote-only, so listing it here as suggested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
