### PR TITLE
Add DABYTE and DABLOCK AI Visibility Index (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎯 <a name="marketing"></a>Marketing
 
+- [DABLOCK AI Visibility Index](https://dablock.ai) `https://dablock.ai/mcp`
+  [![DABLOCK MCP connector](https://glama.ai/mcp/connectors/ai.dablock/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dablock/visibility-index)
+  ⚡ 🔓 🆓 - Weekly share of answer for 24 crypto and Web3 brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
+- [DABYTE AI Visibility Index](https://dabyte.ai) `https://dabyte.ai/mcp`
+  [![DABYTE MCP connector](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index)
+  ⚡ 🔓 🆓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   ⚡ 🔓 🆓 - Audit a site's visibility in AI answer engines (AEO/GEO).


### PR DESCRIPTION
Follow-up to punkpeye/awesome-mcp-servers#11577 — you suggested these belong here rather than in the local-server list. Both are hosted endpoints, so this is the right home.

Adds two entries to **Marketing**, alphabetically before `Lekta`.

**What they are.** Open AI-visibility indexes: how often a brand is named in the answers of ChatGPT, Perplexity and Gemini, measured weekly against a frozen, versioned prompt panel.

- `https://dabyte.ai/mcp` — 20 SaaS and AI-tool brands
- `https://dablock.ai/mcp` — 24 crypto and Web3 brands

**Five read-only tools per server**, identical on both: `get_visibility_index`, `get_brand_visibility`, `list_tracked_brands`, `get_history`, `get_methodology`.

**Checks against CONTRIBUTING.md**

| Requirement | Status |
| --- | --- |
| Public URL answering `initialize` | ✅ both, protocol `2025-06-18` |
| Usable by anyone | ✅ no auth, no account, no per-user URL |
| Streamable HTTP | ✅ `⚡` |
| Glama connector badge resolves | ✅ `ai.dabyte/visibility-index`, `ai.dablock/visibility-index` |
| Alphabetical placement | ✅ DABLOCK, DABYTE, then Lekta |

**Disclosure.** I operate these indexes. The underlying data is CC BY 4.0, every measurement keeps a permanent-URL archive, and placement in the rankings cannot be bought.
