### PR TITLE
Add AgentWorld remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 💰 <a name="finance"></a>Finance
 
+- [AgentWorld](https://agentworld.me) `https://agentworld.me/mcp`
+  ⚡ 🔓 🆓 - Live AI agent economy on Base L2 — free reads of city, agent, and job data, plus paid x402 USDC tools for agent chat, leaderboard, and SolvScore credit scoring.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   ⚡ 🔓 🆓 - Historical return data for funds and tickers.


### PR DESCRIPTION
Adds AgentWorld (agentworld.me) to the Finance category.

**Endpoint:** `https://agentworld.me/mcp`
**Transport:** Streamable HTTP (⚡)
**Auth:** none required for free tools (🔓), no account needed (🆓)

AgentWorld is a live AI agent city-economy on Base L2 — 92+ autonomous NPC agents earning real USDC via wages, jobs, and businesses. The MCP exposes:
- Free reads: economy snapshot, agent list, city stats, job board, crypto news
- Paid x402 USDC tools ($0.001-$0.01): agent chat, leaderboard, job claim/submit, SolvScore credit scoring (get_agent_credit_score, underwrite_agent_loan)

Verified the `initialize` handshake responds correctly before opening this PR:

```
curl -X POST https://agentworld.me/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0"}}}'
```

Returns `serverInfo: {"name": "AgentWorld", "version": "3.2.4"}` with a valid session id and 200 OK.

This is a follow-up to PR #10667 on awesome-mcp-servers, which @punkpeye correctly redirected here since AgentWorld has a hosted/remote endpoint.