### PR TITLE
Add BizIntel 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎯 <a name="marketing"></a>Marketing
 
+- [BizIntel](https://mcp-bizintel-production.up.railway.app) `https://mcp-bizintel-production.up.railway.app/mcp`
+  [![BizIntel MCP connector](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel)
+  🔓 - Audit websites, score local-business leads, detect technology stacks, and find businesses missing websites or booking systems.
 - [DABLOCK AI Visibility Index](https://dablock.ai) `https://dablock.ai/mcp`
   [![DABLOCK MCP connector](https://glama.ai/mcp/connectors/ai.dablock/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dablock/visibility-index)
   🔓 🆓 - Weekly share of answer for 24 crypto and Web3 brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.


### PR DESCRIPTION
Adds BizIntel, a hosted Streamable HTTP MCP server for website audits, technology detection, and local-business lead intelligence.

Verified before submission:
- `initialize` succeeds using protocol `2025-06-18`
- 8 MCP tools are advertised
- exact endpoint: `https://mcp-bizintel-production.up.railway.app/mcp`
- linked Glama connector is healthy