### PR TITLE
Add OpenChainBench 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Octagon](https://octagonagents.com) `https://mcp.octagonagents.com/mcp`
   [![Octagon MCP connector](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon/badges/score.svg)](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon)
   🔐 💰 - Private- and public-market financial research data.
+- [OpenChainBench](https://openchainbench.com) `https://openchainbench.com/api/mcp/mcp`
+  🔓 🆓 - Live crypto infrastructure benchmarks: RPC latency, bridge fees and times, aggregator head lag, and perp DEX funding, with PromQL access to the underlying time series.
 - [Plaid](https://plaid.com) `https://api.dashboard.plaid.com/mcp/sse`
   🔑 - Query Plaid dashboard data for connected financial accounts.
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`


### PR DESCRIPTION
Moved here from [punkpeye/awesome-mcp-servers#7919](https://github.com/punkpeye/awesome-mcp-servers/pull/7919), which was closed today with a pointer to this list. OpenChainBench is a hosted Streamable HTTP server, so it belongs here rather than there.

**Entry** (Finance, alphabetical between Octagon and Plaid):

```markdown
- [OpenChainBench](https://openchainbench.com) `https://openchainbench.com/api/mcp/mcp`
  🔓 🆓 - Live crypto infrastructure benchmarks: RPC latency, bridge fees and times, aggregator head lag, and perp DEX funding, with PromQL access to the underlying time series.
```

**Against the requirements**

- **Public URL, answers `initialize`.** Verified just now:
  ```
  POST https://openchainbench.com/api/mcp/mcp
  → {"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":true},"resources":{"listChanged":true}}},...}
  ```
- **Usable by anyone.** No auth, no account, no per-user endpoint. Hence 🔓 🆓.
- **Streamable HTTP**, spec revision 2025-06-18, with SSE fallback. Nothing runs locally.

**Tools:** `list_benchmarks`, `get_benchmark`, `query_prom` (PromQL passthrough over the published benchmark metrics).

The data behind it is 218 live benchmarks, published daily as Parquet under CC BY 4.0 with a Zenodo DOI. Server source is MIT.

No Glama connector badge yet: OpenChainBench is listed at `glama.ai/mcp/servers` but has no `glama.ai/mcp/connectors` entry, and CI fails on a badge pointing at a missing connector. Submitting the connector separately and happy to add the badge in a follow-up once it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)