### PR TITLE
Add Imaginode to Multimedia 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎥 <a name="multimedia"></a>Multimedia
 
+- [Imaginode](https://imaginode.ai) `https://imaginode.ai/api/mcp`
+  🔑 - Generate images and video from a prompt across 89 models, with the credit cost returned before each result.
 - [invideo](https://invideo.io) `https://mcp.invideo.io/mcp`
   🔓 🆓 - Generate and edit videos from a prompt.
 


### PR DESCRIPTION
Adds Imaginode to the Multimedia section, in alphabetical order before invideo.

- Endpoint: `https://imaginode.ai/api/mcp` (Streamable HTTP)
- Auth: 🔑 API key (`imk_…`), created in the account profile
- Access: normal account, trial credits included, so no access marker
- Source: https://github.com/Frankhoubre/imaginode-mcp
- Also published on the official MCP registry under the domain-verified namespace `ai.imaginode/imaginode`

The server generates images and video from a prompt across the imaginode.ai catalogue, and returns the exact credit cost of each generation before the result. Failed generations are refunded automatically.

Disclosure: opened by an agent on behalf of the maintainer, marked per CONTRIBUTING.md.