### PR TITLE
Add DripRaven to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 🆓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
 - [DripRaven](https://dripraven.com) `https://app.dripraven.com/mcp`
   [![DripRaven MCP connector](https://glama.ai/mcp/connectors/com.dripraven/dripraven/badges/score.svg)](https://glama.ai/mcp/connectors/com.dripraven/dripraven)
-  🔐 💰 - Run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats.
+  🔐 - Run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 🆓 - Audit a site's visibility in AI answer engines (AEO/GEO).

--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [DABYTE AI Visibility Index](https://dabyte.ai) `https://dabyte.ai/mcp`
   [![DABYTE MCP connector](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index)
   🔓 🆓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
+- [DripRaven](https://dripraven.com) `https://app.dripraven.com/mcp`
+  [![DripRaven MCP connector](https://glama.ai/mcp/connectors/com.dripraven/dripraven/badges/score.svg)](https://glama.ai/mcp/connectors/com.dripraven/dripraven)
+  🔐 - Run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 🆓 - Audit a site's visibility in AI answer engines (AEO/GEO).

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 🆓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
 - [DripRaven](https://dripraven.com) `https://app.dripraven.com/mcp`
   [![DripRaven MCP connector](https://glama.ai/mcp/connectors/com.dripraven/dripraven/badges/score.svg)](https://glama.ai/mcp/connectors/com.dripraven/dripraven)
-  🔐 - Run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats.
+  🔐 💰 - Run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 🆓 - Audit a site's visibility in AI answer engines (AEO/GEO).


### PR DESCRIPTION
Adding **DripRaven** under Marketing, moved over from punkpeye/awesome-mcp-servers#11829 as suggested.

- Homepage: https://dripraven.com
- Endpoint: `https://app.dripraven.com/mcp` (Streamable HTTP, OAuth 2.1)
- Glama connector: https://glama.ai/mcp/connectors/com.dripraven/dripraven
- Also listed in the official MCP registry as `com.dripraven/dripraven`

DripRaven lets an AI assistant run WhatsApp Business campaigns: import contacts, build live segments, send approved message templates, schedule broadcasts, and read delivery and read stats over the official WhatsApp Business API.

The endpoint is public and open to sign-up; unauthenticated requests return `401` with a `WWW-Authenticate` header pointing at `https://app.dripraven.com/.well-known/oauth-protected-resource`.

Entry placed in alphabetical order within Marketing.