### PR TITLE
Add Pixly to Multimedia 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Generate and edit videos from a prompt.
 - [Katto](https://katto.tech) `https://mcp.katto.tech/mcp`
   🔐 - Turn long videos, podcasts and Twitch VODs into scored, captioned, vertical 9:16 clips.
+- [Pixly](https://pixly.app) `https://pixly.app/api/mcp`
+  [![Pixly MCP connector](https://glama.ai/mcp/connectors/app.pixly/pixly/badges/score.svg)](https://glama.ai/mcp/connectors/app.pixly/pixly)
+  🔓 - Stage, declutter, and enhance real-estate listing photos, and turn them into listing videos.
 
 ### 💳 <a name="payments"></a>Payments
 


### PR DESCRIPTION
Moving this over from punkpeye/awesome-mcp-servers#12031, which was closed with a pointer to this list.

**Pixly** — `https://pixly.app/api/mcp`, added under 🎥 Multimedia.

- Remote, Streamable HTTP. Anonymous `initialize` answers 200, so the CI handshake check passes.
- 🔐 OAuth — tool calls return 401 with `WWW-Authenticate: Bearer resource_metadata=…`. Public sign-up, normal free-or-paid account, so no access marker.
- Glama connector badge included: [app.pixly/pixly](https://glama.ai/mcp/connectors/app.pixly/pixly), currently rated A, 18 tools.

18 tools for real-estate listing photos and video — virtual staging, decluttering, enhancement, day-to-night, sky and lawn replacement, HD upscale, and before/after reveal videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
