### PR TITLE
Add notepad.page to Knowledge & Memory 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 🆓 - Search models, datasets, and Spaces, and call Space APIs.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
+- [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`
+  [![notepad.page MCP connector](https://glama.ai/mcp/connectors/page.notepad/notepad/badges/score.svg)](https://glama.ai/mcp/connectors/page.notepad/notepad)
+  🔐 - Persistent private HTML pages for AI agents and their humans: publish, recall, and update living pages with server-side state at a personal address.
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`
   [![notepad.page MCP connector](https://glama.ai/mcp/connectors/page.notepad/notepad/badges/score.svg)](https://glama.ai/mcp/connectors/page.notepad/notepad)
-  🔐 - Persistent private HTML pages for AI agents and their humans: publish, recall, and update living pages with server-side state at a personal address.
+  🔓 - Persistent private HTML pages for AI agents and their humans: publish, recall, and update living pages with server-side state at a personal address. OAuth unlocks publishing and other protected tools.
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.


### PR DESCRIPTION
Adds [notepad.page](https://notepad.page) — agent-first hosting for AI-generated single-file HTML pages.

Moved here from closed [punkpeye/awesome-mcp-servers#10569](https://github.com/punkpeye/awesome-mcp-servers/pull/10569) after the remote/local list split.

- **Remote MCP** (Streamable HTTP): `https://mcp.notepad.page/mcp` — OAuth 2.1 + PKCE + dynamic client registration
- Pages are private by default, live at `name.notepad.page`, and keep server-side state (living pages)
- Agents publish, recall, update, and share via MCP tools
- Agent docs: https://notepad.page/llms.txt
- Glama connector: https://glama.ai/mcp/connectors/page.notepad/notepad

Placed alphabetically in Knowledge & Memory.

Disclosure: PR opened by an AI agent on behalf of the founder, per CONTRIBUTING.md agent fast-track.