### PR TITLE
Add TaskFuel

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🔗 <a name="aggregators"></a>Aggregators
 
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
+  [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)
   🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.
 - [Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
   [![Zapier MCP connector](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier/badges/score.svg)](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔗 <a name="aggregators"></a>Aggregators
 
+- [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
+  🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.
 - [Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
   [![Zapier MCP connector](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier/badges/score.svg)](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier)
   🔐 - Run your Zapier actions across thousands of connected apps as MCP tools.


### PR DESCRIPTION
**Server:** TaskFuel
**Endpoint:** `https://app.taskfuel.ai/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

TaskFuel is a gateway for pay-per-call HTTP-402 APIs. The server exposes `discover` (keyword search over a curated catalog of provider endpoints, then full docs for a given URL and method), `call` (with a `dry_run` that reads the real price off the 402 challenge), `get_result`, `rate`, `feedback`, and `balance`. The gateway pays the upstream and debits the user's prepaid USD balance, so the agent never touches a wallet or a payment protocol.

Listed under **Aggregators** because one endpoint fronts many providers' APIs rather than a single service's own.

Notes on the markers:

- 🔐 — OAuth 2.0 with dynamic client registration is the primary path (an `sk-402-…` API key also works). Unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer … resource_metadata=…` pointing at the RFC 9728 document, so the CI probe should read 🔐.
- No access marker — every account starts with free credit, so it is a normal free-or-paid account rather than a 💰 paid plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
