### PR TITLE
Add Accordo docs MCP server (Developer Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🛠️ <a name="developer-tools"></a>Developer Tools
 
+- [Accordo](https://accordo.dev) `https://accordo.dev/api/mcp`
+  🔓 🆓 - Search Accordo's documentation, fetch a capability together with the limitation that bounds it, and check whether a CRM job is supported.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 🆓 - Search the Astro documentation.
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`


### PR DESCRIPTION
**Server:** Accordo — read-only documentation server for an open-source CRM framework that coding agents build with. Source: https://github.com/khaoss85/agent-crm (MIT); also in the official MCP Registry as `io.github.khaoss85/agent-crm`.
**Endpoint:** `https://accordo.dev/api/mcp` (Streamable HTTP, no auth, no account)

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Three read-only tools over the published documentation corpus: `search_docs`, `get_capability` (returns a capability together with the limitation that bounds it) and `check_job` (answers over a CRM jobs matrix whose default status is "not supported"). The server opens no database and holds no customer record.

Resubmitted here from punkpeye/awesome-mcp-servers#12938, closed on the maintainer's request to move hosted servers to this list.

No Glama connector badge yet: Accordo is not listed on glama.ai/mcp/connectors, and a badge for a missing connector fails the check.