### PR TITLE
Add BioVet 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 
 - [BioVet](https://bio.vet/) `https://bio.vet/mcp`
-  🔓 🆓 - Find a 24/7 veterinary clinic in Moscow, check live prices and doctor availability, book a visit, and triage symptoms or foods for urgency.
+  [![BioVet MCP connector](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp)
+  🔓 - Find a 24/7 vet clinic in Moscow, check live prices and free doctor slots, book a visit, and triage symptoms.
 - [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
   [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 
+- [BioVet](https://bio.vet/) `https://bio.vet/mcp`
+  🔓 🆓 - Find a 24/7 veterinary clinic in Moscow, check live prices and doctor availability, book a visit, and triage symptoms or foods for urgency.
 - [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
   [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.


### PR DESCRIPTION
Moving this over from punkpeye/awesome-mcp-servers#13323 — it is a hosted server, so it belongs here.

**Endpoint:** `https://bio.vet/mcp` (Streamable HTTP, no auth, no account needed)

BioVet is a network of 20 round-the-clock veterinary clinics in Moscow. The server exposes the same live data the site runs on: clinic search with live ratings, prices straight from the clinic management system, doctor availability, booking, symptom triage and a food-safety checker.

Tools: `find_clinic`, `get_prices`, `check_slots`, `book_visit`, `triage`, `food_check`, `ask_vet_kb`.

Dosages and treatment advice are deliberately out of scope — triage routes to a vet, it does not diagnose.

Manifest: https://bio.vet/.well-known/mcp.json · source: https://github.com/Bio-Vet/biovet-mcp

Handshake check:
```
curl -s -X POST https://bio.vet/mcp -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"check","version":"1"}}}'
```

No Glama connector badge yet — the connector is not listed there, so I left the badge out rather than point at a missing one.