### PR TITLE
Add Bisque to Multimedia 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🎥 <a name="multimedia"></a>Multimedia
 
 - [Bisque](https://bisque.today) `https://bisque.cloud/presentations/mcp`
-  🔐 - Author narrated presentations and publish them to a shareable watch URL.
+  🔓 - Author narrated presentations and publish them to a shareable watch URL; tool calls need a free Bisque account.
 - [invideo](https://invideo.io) `https://mcp.invideo.io/mcp`
   🔓 🆓 - Generate and edit videos from a prompt.
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎥 <a name="multimedia"></a>Multimedia
 
+- [Bisque](https://bisque.today) `https://bisque.cloud/presentations/mcp`
+  🔐 - Author narrated presentations and publish them to a shareable watch URL.
 - [invideo](https://invideo.io) `https://mcp.invideo.io/mcp`
   🔓 🆓 - Generate and edit videos from a prompt.
 


### PR DESCRIPTION
Adds one entry to **🎥 Multimedia**, alphabetically before `invideo`.

```
- [Bisque](https://bisque.today) `https://bisque.cloud/presentations/mcp`
  🔐 - Author narrated presentations and publish them to a shareable watch URL.
```

Remote Streamable HTTP endpoint, OAuth 2.1 with browser sign-in (an API key also works). `initialize`, `tools/list`, `resources/read` and `prompts/get` answer anonymously; `tools/call` needs a credential. Public sign-up at [bisque.today](https://bisque.today), free tier included.

Eight tools: `get_presentation_spec`, `create_presentation`, `get_presentation_status`, `list_presentations`, `get_presentation_analytics`, `get_presentation_context`, `create_artifact`, `share_artifact`.

Handshake as of today:

```
$ curl -sS -X POST https://bisque.cloud/presentations/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'

{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{},"prompts":{},"resources":{}},"serverInfo":{"name":"bisque-presentations","title":"Bisque Presentations","version":"1.0.0"}, ...}}
```

Re-filed from punkpeye/awesome-mcp-servers#13426, closed in favor of this list. No Glama connector badge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbGzP4i1wtXLBA7b8UUU9z