### PR TITLE
Add volai to Communication 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Send transactional email and manage sending domains.
 - [volai](https://volai.cz/en) `https://volai.cz/mcp`
   [![volai MCP connector](https://glama.ai/mcp/connectors/cz.volai/volai/badges/score.svg)](https://glama.ai/mcp/connectors/cz.volai/volai)
-  🔑 - Buy Czech and Slovak phone numbers, place calls, send SMS, and run a voice agent that answers them.
+  🔐 - Buy Czech and Slovak numbers, place calls, send SMS, run a voice agent; auth is an API key sent as a Bearer token.
 
 ### 📝 <a name="content-management"></a>Content Management
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Resend](https://resend.com) `https://mcp.resend.com/mcp`
   🔐 - Send transactional email and manage sending domains.
+- [volai](https://volai.cz/en) `https://volai.cz/mcp`
+  [![volai MCP connector](https://glama.ai/mcp/connectors/cz.volai/volai/badges/score.svg)](https://glama.ai/mcp/connectors/cz.volai/volai)
+  🔑 - Buy Czech and Slovak phone numbers, place calls, send SMS, and run a voice agent that answers them.
 
 ### 📝 <a name="content-management"></a>Content Management
 


### PR DESCRIPTION
Moved here from [awesome-mcp-servers#13472](https://github.com/punkpeye/awesome-mcp-servers/pull/13472), which was closed with a pointer to this list. volai is a hosted server, so it belongs here.

**Entry** (Communication, alphabetically after Resend):

- Endpoint: `https://volai.cz/mcp`, Streamable HTTP, nothing to install or run locally.
- Auth: `Authorization: Bearer vk_...` API key from the portal.
- Docs: https://volai.cz/en/docs/mcp
- Glama connector: https://glama.ai/mcp/connectors/cz.volai/volai (badge included in the entry).

volai is a Czech telephony provider for developers and AI agents: buy +420 and +421 numbers, place and receive calls, send SMS, and attach a voice agent to a number, all through one REST API and this MCP server, billed per second.

**Auth marker.** The entry uses 🔐 because that is what the submission check reports: an unauthenticated `initialize` gets a `401` with `WWW-Authenticate: Bearer ... resource_metadata=...` (RFC 9728). There is no authorization server behind that pointer, only a static API key sent as a Bearer token, so the description says so explicitly - the same approach as #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyKrx4yGaUaviKsPcHNRcK
