### PR TITLE
Add Agentic Atlas remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🛠️ <a name="developer-tools"></a>Developer Tools
 
+- [Agentic Atlas](https://agentic-atlas.dev/) `https://agentic-atlas.dev/mcp/`
+  🔓 🆓 - Find and read agent-design patterns, decision guidance, and relationships through five read-only tools.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 🆓 - Search the Astro documentation.
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Agentic Atlas](https://agentic-atlas.dev/) `https://agentic-atlas.dev/mcp/`
   [![Agentic Atlas MCP connector](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas/badges/score.svg)](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas)
-  🔓 🆓 - Find and read agent-design patterns, decision guidance, and relationships through five read-only tools.
+  🔓 - Find and read agent-design patterns, decision guidance, and relationships through five read-only tools.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 🆓 - Search the Astro documentation.
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🛠️ <a name="developer-tools"></a>Developer Tools
 
 - [Agentic Atlas](https://agentic-atlas.dev/) `https://agentic-atlas.dev/mcp/`
+  [![Agentic Atlas MCP connector](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas/badges/score.svg)](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas)
   🔓 🆓 - Find and read agent-design patterns, decision guidance, and relationships through five read-only tools.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 🆓 - Search the Astro documentation.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Agentic Atlas](https://agentic-atlas.dev/) `https://agentic-atlas.dev/mcp/`
   [![Agentic Atlas MCP connector](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas/badges/score.svg)](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas)
-  🔓 - Find and read agent-design patterns, decision guidance, and relationships through five read-only tools.
+  🔓 - Give AI agents a field guide to building better agents, with design patterns, tradeoffs, and decision guidance.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 🆓 - Search the Astro documentation.
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`


### PR DESCRIPTION
**Server:** [Agentic Atlas](https://agentic-atlas.dev/)
**Endpoint:** `https://agentic-atlas.dev/mcp/`
**Glama connector:** [Agentic Atlas](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas)

Adds Agentic Atlas to Developer Tools. Its five read-only tools help agents find and read agent-design patterns, decision guidance, and relationships. The hosted Streamable HTTP endpoint requires no authentication or account.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Validation: an anonymous `initialize` request with protocol version `2025-06-18` returned HTTP 200 and identified Agentic Atlas v1.0.6. The entry follows the three-line format with the Glama connector badge and description length limit; `git diff --check` passes.
