### PR TITLE
fix(ci): sniff SSE by content-type, and infer auth from a tool call 🤖🤖🤖

### DIFF
--- a/.github/workflows/check-submission.yml
+++ b/.github/workflows/check-submission.yml
@@ -126,31 +126,61 @@ jobs:
               },
             });
 
+            function mcpPost(url, body) {
+              return fetch(url, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Accept': 'application/json, text/event-stream',
+                  'MCP-Protocol-Version': '2025-06-18',
+                  'User-Agent': 'awesome-remote-mcp-servers-ci/1.0',
+                },
+                body,
+                redirect: 'follow',
+                signal: AbortSignal.timeout(20000),
+              });
+            }
+
+            function authFromChallenge(res) {
+              const wa = res.headers.get('www-authenticate') || '';
+              return /resource_metadata|Bearer/i.test(wa) ? '🔐' : '🔑';
+            }
+
+            // An open `initialize` is the recommended shape for an authenticated
+            // server — it lets a client read the catalog before it holds a token,
+            // and directory health checks rely on it — so a parsed result says
+            // nothing about whether the tools are gated. Ask for actual work and
+            // see whether the server challenges us.
+            async function authFromToolCall(url) {
+              try {
+                const res = await mcpPost(url, JSON.stringify({
+                  jsonrpc: '2.0', id: 2, method: 'tools/call',
+                  params: { name: '__ci_probe__', arguments: {} },
+                }));
+                if (res.status === 401 || res.status === 403) return authFromChallenge(res);
+                return '🔓';
+              } catch { return '🔓'; }
+            }
+
             async function probe(url) {
               try {
-                const res = await fetch(url, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json, text/event-stream',
-                    'MCP-Protocol-Version': '2025-06-18',
-                    'User-Agent': 'awesome-remote-mcp-servers-ci/1.0',
-                  },
-                  body: initBody,
-                  redirect: 'follow',
-                  signal: AbortSignal.timeout(20000),
-                });
+                const res = await mcpPost(url, initBody);
                 if (res.status === 401 || res.status === 403) {
-                  const wa = res.headers.get('www-authenticate') || '';
-                  return { ok: true, auth: /resource_metadata|Bearer/i.test(wa) ? '🔐' : '🔑', status: res.status };
+                  return { ok: true, auth: authFromChallenge(res), status: res.status };
                 }
                 const text = (await res.text()).slice(0, 20000);
-                const payload = text.includes('data:')
+                // Sniff the header, not the body. A server whose `instructions`
+                // string documents a data URI would otherwise be parsed as an
+                // event stream, match no frames, and be reported unreachable.
+                const isSse = (res.headers.get('content-type') || '').includes('text/event-stream');
+                const payload = isSse
                   ? text.split('\n').filter(l => l.startsWith('data:')).map(l => l.slice(5).trim()).join('')
                   : text;
                 let json = null;
                 try { json = JSON.parse(payload); } catch {}
-                if (json && json.result) return { ok: true, auth: '🔓', status: res.status };
+                if (json && json.result) {
+                  return { ok: true, auth: await authFromToolCall(url), status: res.status };
+                }
                 return { ok: false, status: res.status, why: `no initialize result (HTTP ${res.status})` };
               } catch (err) {
                 return { ok: false, why: String(err.message || err).slice(0, 120) };


### PR DESCRIPTION
Two false positives in `probe()`, both hit while submitting #24. Endpoint behaviour is unchanged for every server already on the list — measured, see the table.

### 1. The SSE sniff tests the body, not the header

```js
const payload = text.includes('data:') ? /* extract data: frames */ : text;
```

Any `initialize` response containing the substring `data:` takes the SSE branch. A server whose `instructions` string documents image input as a data URI — a common thing for media servers to say — has no *line* starting with `data:` in its single-line JSON body, so the filter yields nothing, `payload` becomes `""`, `JSON.parse` throws, and the server is reported unreachable. That's what happened in #24.

Now sniffed from `content-type`, which is what actually distinguishes the two transports.

### 2. Auth is inferred from `initialize` alone

`probe()` returns 🔓 whenever an `initialize` result parses. But leaving `initialize` (and often `tools/list`) open is the recommended shape for an *authenticated* server — it lets a client read the catalog before it holds a token, and Glama's health check depends on exactly that. So a parsed result isn't evidence of an open server.

Servers built that way get labelled 🔓 — "connect anonymously" — and a reader following that gets a 401 on their first tool call.

Now, when `initialize` succeeds anonymously, the probe follows up with a `tools/call` and reads the challenge: 401/403 with `WWW-Authenticate` → 🔐 or 🔑, anything else → 🔓. Servers that already challenge at `initialize` are unaffected — that path is untouched.

### Measured against live entries

Both probes, old and new, run against endpoints currently in the README:

| endpoint | listed | old | new |
| --- | --- | --- | --- |
| `mcp.invideo.io/mcp` | 🔓 | ok 🔓 | ok 🔓 |
| `dablock.ai/mcp` | 🔓 | ok 🔓 | ok 🔓 |
| `mcp.logokit.com/mcp` | 🔑 | ok 🔑 | ok 🔑 |
| `mcp.sentry.dev/mcp` | 🔐 | ok 🔐 | ok 🔐 |
| `mcp.paypal.com/mcp` | 🔐 | ok 🔐 | ok 🔐 |
| `pixly.app/api/mcp` (#24) | 🔐 | ok **🔓** | ok **🔐** |

Only the misclassified one moves. One extra request per server, and only for servers whose handshake is open.

Note this workflow runs from the base branch under `pull_request_target`, so the check on *this* PR exercises the old code, not the new — the table above is the evidence instead. The `contents: read` / base-ref checkout is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
