### PR TITLE
Add HeyYumi (Food & Dining) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 * 🌳 - [Environment](#environment)
 * 📂 - [File Storage](#file-storage)
 * 💰 - [Finance](#finance)
+* 🍽️ - [Food & Dining](#food--dining)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * 🎯 - [Marketing](#marketing)
 * 📊 - [Monitoring](#monitoring)
@@ -245,6 +246,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`
   [![Vantage MCP connector](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage)
   🔐 - Ask questions about cloud cost and usage data.
+
+### 🍽️ <a name="food--dining"></a>Food & Dining
+
+- [HeyYumi](https://heyyumi.ai) `https://mcp.heyyumi.ai/mcp`
+  [![HeyYumi MCP connector](https://glama.ai/mcp/connectors/ai.heyyumi/heyyumi/badges/score.svg)](https://glama.ai/mcp/connectors/ai.heyyumi/heyyumi)
+  🔐 - Search verified Korean restaurants and bars by filters, then request a table booking in chat.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
**Server:** HeyYumi
**Endpoint:** `https://mcp.heyyumi.ai/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Moved here from punkpeye/awesome-mcp-servers#13474, which was closed with a pointer to this list.

HeyYumi is a hosted MCP server over verified Korean food and drink venue data. Its tools search and filter venues (cuisine, atmosphere, dietary needs, wheelchair access, open-at-a-given-time, reservation channel), return full venue detail with photos, and can send a table booking request to the owner's app and wait for the answer in the same conversation.

A new `Food & Dining` category was added because nothing existing fit; the index at the top was updated in the same order as the sections.

Notes for CI:

- Unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer ... resource_metadata="https://mcp.heyyumi.ai/.well-known/oauth-protected-resource"`, so the auth marker is 🔐. API keys are also accepted as `Authorization: Bearer <key>`, self-serve at heyyumi.ai.
- Glama connector already listed at `ai.heyyumi/heyyumi`, so the badge resolves.
