### PR TITLE
Add FoxForm to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [DABYTE AI Visibility Index](https://dabyte.ai) `https://dabyte.ai/mcp`
   [![DABYTE MCP connector](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index)
   🔓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
+- [FoxForm](https://foxform.app) `https://mcp.foxform.app/mcp`
+  [![FoxForm MCP connector](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form/badges/score.svg)](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form)
+  🔓 - Build scored forms, quizzes and calculators, publish them, and read responses with per-screen analytics.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 - Audit a site's visibility in AI answer engines (AEO/GEO).


### PR DESCRIPTION
Adds FoxForm to the **Marketing** section, in alphabetical position between DABYTE and Lekta.

FoxForm builds forms, quizzes and calculators where every answer carries points into a score, and the score decides which screen comes next and which result the person sees. `calc()` expressions run inside the page for quotes and ROI. Published forms are served as static HTML from a CDN.

The endpoint speaks Streamable HTTP and exposes 10 tools: list, get, create, update, publish and unpublish a form; list, get and export responses; and per-screen analytics.

**On the auth marker.** `initialize` and `tools/list` answer anonymously, on purpose, so clients and directories can introspect the tool set before anyone signs in. That is why the marker is 🔓, and it matches what the CI probe sees. `tools/call` does require a FoxForm account, over OAuth (metadata discovery, dynamic client registration and PKCE, all on the same host) or an API key. Happy to switch to 🔐 if you would rather the marker describe calling tools than opening the connection.

Glama connector: `app.foxform.mcp/fox-form`.

Resubmitted here from punkpeye/awesome-mcp-servers#13173, as you asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
