### PR TITLE
Add Gemalli — global B2B trade platform (sanctions screening, HS codes) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [FTIR.fun](https://ftir.fun) `https://ftir.fun/mcp`
   [![FTIR.fun Spectral Search MCP connector – tool definition quality and endpoint health on Glama](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jxbaoxiaodong/ftirfun-mcp)
   🔐 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
+- [Gemalli](https://gemalli.com/en/developers) `https://gemalli.com/api/mcp`
+  [![Gemalli MCP connector](https://glama.ai/mcp/connectors/com.gemalli/trade/badges/score.svg)](https://glama.ai/mcp/connectors/com.gemalli/trade)
+  🔓 🆓 - Search verified manufacturers, screen counterparties against UN/OFAC/EU sanctions lists, and look up HS codes and dual-use export controls for cross-border trade.
 - [gluten-free.fr](https://gluten-free.fr) `https://gluten-free.fr/api/mcp`
   🔓 🆓 - Verified gluten-free product catalogue and comparison data for the French market.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`


### PR DESCRIPTION
Moved here from awesome-mcp-servers#13314 — thanks for the pointer, this list is the right home for a hosted server.

**Endpoint:** `https://gemalli.com/api/mcp` (Streamable HTTP, protocol `2025-06-18`)
**Docs:** https://gemalli.com/en/developers
**Glama connector:** https://glama.ai/mcp/connectors/com.gemalli/trade

### Against the listing requirements

* **Reachable at a public URL** — answers `initialize` anonymously; verified just now.
* **Usable by anyone** — no account, no key. 13 tools are listed and callable anonymously; `🔓 🆓` reflects that.
* **Streamable HTTP** — no local process involved.

Not a per-user endpoint and not behind a paywall.

### What the tools do

Sourcing (`search_products`, `list_manufacturers`, `get_product`, `get_manufacturer`, `list_categories`) plus the part agents usually have to leave the conversation for: `check_sanctions` screens a counterparty against UN/OFAC/EU lists, `lookup_hs_code` classifies goods, and `check_dual_use` flags export-control exposure. `request_quote` sends an RFQ to a manufacturer without the buyer needing an account first.

Placed under **Search & Data Extraction**, alphabetically between FTIR.fun and gluten-free.fr.
