### PR TITLE
Add Sector Pulse (Finance) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Private- and public-market financial research data.
 - [Plaid](https://plaid.com) `https://api.dashboard.plaid.com/mcp/sse`
   🔑 - Query Plaid dashboard data for connected financial accounts.
+- [Sector Pulse](https://sector-pulse.app) `https://sector-pulse.app/api/mcp`
+  [![Sector Pulse MCP connector](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse)
+  🔓 - Live US sector rotation: 30 sector baskets ranked every session, versioned rosters, daily record; history needs a key.
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`
   [![Vantage MCP connector](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage)
   🔐 - Ask questions about cloud cost and usage data.


### PR DESCRIPTION
Adds Sector Pulse to Finance, moved here from awesome-mcp-servers #13892 at the maintainer's request.

- Endpoint: `https://sector-pulse.app/api/mcp` (Streamable HTTP)
- Tools: `get_sectors` (live board, no auth), `get_roster` and `get_history` (Sector API key in `x-api-key` or `Authorization: Bearer`)
- Glama connector: https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse (claimed, scored)
- Official registry: `io.github.christianhonap7-sys/sector-pulse`
- Docs: https://sector-pulse.app/api-docs · OpenAPI: https://sector-pulse.app/openapi.json

What it does: 30 US sector baskets ranked by average move every session from the tape, versioned basket rosters, and a daily close record kept since July and never backfilled. Aggregates only, no quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)