### PR TITLE
Add Atlas Red — mind map MCP connector (Knowledge & Memory) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 
+- [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
+  [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
+  🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.


### PR DESCRIPTION
Moving here from punkpeye/awesome-mcp-servers#13154, which was closed with the remote-server split notice.

**Atlas Red** — `https://app.atlas-red.com/mcp`

A mind mapping app with an MCP server, so the map is something an assistant builds and edits directly: create a map, add nodes, links and whole subtrees, extract or replace a subtree, import and export, and render the map as an image.

- **Homepage / docs:** https://atlas-red.com/mind-map-mcp
- **Auth:** OAuth (🔐). An `initialize` without a token returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://app.atlas-red.com/api/auth/.well-known/oauth-protected-resource"`.
- **Transport:** Streamable HTTP.
- **Access marker:** none — it comes with a normal account that has a free tier, so per CONTRIBUTING neither 🆓 nor 💰 applies.
- **Glama connector:** https://glama.ai/mcp/connectors/com.atlas-red/mind-map (auto-imported from the official MCP registry, where the server is published as `com.atlas-red/mind-map`).

Placed in Knowledge & Memory, alphabetically ahead of Hugging Face.

Small note in case it is useful: the connector page is still unclaimed. The `/.well-known/glama.json` file has been live on both `app.atlas-red.com` and `atlas-red.com` since 29 August with the account email on it, and verification has not picked it up. Happy to move that to Discord if this is the wrong place for it.