### PR TITLE
Add Mailcoach to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [LogoKit](https://logokit.com) `https://mcp.logokit.com/mcp`
   [![LogoKit MCP connector](https://glama.ai/mcp/connectors/com.logokit/brand-data/badges/score.svg)](https://glama.ai/mcp/connectors/com.logokit/brand-data)
   🔑 - Company logos, brand colors, and firmographic data by domain.
+- [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
+  🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
Adds Mailcoach’s official MCP server under Marketing, in alphabetical order.

The server uses Streamable HTTP and OAuth at `https://mcp.mailcoach.app`. Assistants can get the current Mailcoach context, inspect email lists, look up subscribers, review campaigns, statistics and templates, and read recent transactional email logs.

Access is read-only by default. Optional write access allows creating and updating draft campaigns and templates, and sending campaign test emails. There is no tool for sending campaigns to the full audience.
