### PR TITLE
Add GovAuctions.app to Search & Data Extraction 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Verified gluten-free product catalogue and comparison data for the French market.
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
   [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
-  🔑 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
+  🔓 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`

--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
 - [gluten-free.fr](https://gluten-free.fr) `https://gluten-free.fr/api/mcp`
   🔓 - Verified gluten-free product catalogue and comparison data for the French market.
+- [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
+  [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
+  🔑 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`


### PR DESCRIPTION
Moved here from punkpeye/awesome-mcp-servers#13641, which was closed with a pointer to this list.

**What it is:** GovAuctions.app is a free public site for searching live government surplus auctions (vehicles, equipment, electronics, seized property) and checking what comparable lots actually sold for before bidding. The remote server exposes that same data to agents.

- **Endpoint:** `https://govauctions.app/api/mcp`, Streamable HTTP, answers `initialize` anonymously (protocol 2024-11-05, serverInfo `govauctions.app` 1.0.2).
- **Auth:** 🔑 — API key as `Authorization: Bearer` or `x-api-key`. Public sign-up, free tier at https://govauctions.app/developers.
- **Tools (8):** `search_listings`, `get_listing`, `get_sold_comps`, `get_flip_score`, `get_sold_history`, `get_price_trend`, `get_comp_coverage`, `get_api_usage`.
- **Glama connector:** `app.govauctions/govauctions` — rated A, endpoint responding, 8 tools.
- Also in the official MCP registry as `app.govauctions/govauctions` (v1.0.2).

Entry is 3 lines in the documented format, description is 110 characters ending in a period, inserted in case-insensitive alphabetical order between `gluten-free.fr` and `Simplescraper`.

**Disclosure:** this PR was prepared by an AI agent working for Ben Wallace, who operates GovAuctions.app. It is a commercial site with a free tier, so there is a commercial interest in the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)