### PR TITLE
Add AdminHub for Telegram 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 📣 <a name="social-media"></a>Social Media
 
+- [AdminHub for Telegram](https://adminhub.tools/mcp/) `https://backend-git-production-cb93.up.railway.app/mcp`
+  [![AdminHub for Telegram MCP connector](https://glama.ai/mcp/connectors/tools.adminhub/telegram/badges/score.svg)](https://glama.ai/mcp/connectors/tools.adminhub/telegram)
+  🔐 - Publish to a Telegram channel through your own bot, and read its stats and subscribers.
 - [OmniSocials](https://omnisocials.com) `https://mcp.omnisocials.com/`
   [![OmniSocials MCP connector](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials/badges/score.svg)](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials)
   🔑 - Publish and schedule posts across social networks.


### PR DESCRIPTION
Adds **AdminHub for Telegram** under Social Media.

A hosted MCP server for running a Telegram channel from an AI agent: fourteen tools covering the workspace, channels, posts (create, schedule, publish, edit, retry delivery, attach an image) and subscribers.

What makes it different from the Telegram MCP servers already around: publishing goes through a bot the channel owner created for their own channel, never a shared bot and never a personal account. No MTProto userbot, so there is no account of the user's to get limited or banned.

- **Endpoint:** `https://backend-git-production-cb93.up.railway.app/mcp` — same URL for every user, Streamable HTTP.
- **Auth:** OAuth 2.1, PKCE S256, Client ID Metadata Documents and DCR, resource indicators. Unauthenticated `initialize` answers `401` with `WWW-Authenticate: Bearer … resource_metadata=…`, so the CI probe should read it as 🔐. Sign-up is public and free.
- **Registry:** published as `tools.adminhub/telegram`.
- **Badge:** the Glama connector `tools.adminhub/telegram` exists and its page returns 200.

Docs: https://adminhub.tools/mcp/ and a setup guide at https://adminhub.tools/blog/telegram-mcp-setup/