### PR TITLE
Add Finology Software to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`
   [![Vantage MCP connector](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage)
   🔐 - Ask questions about cloud cost and usage data.
+- [Finology Software](https://finology.tech/developers/) `https://mcp.finology.tech/mcp`
+  🔑 - US federal student loan payments, forgiveness timing and tax, cited to primary sources.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Moved here from [awesome-mcp-servers#13924](https://github.com/punkpeye/awesome-mcp-servers/pull/13924) as directed — thanks for the pointer.

**[Finology Software](https://finology.tech/developers/)** — `https://mcp.finology.tech/mcp`, Streamable HTTP, 🔑.

US federal student loan repayment math: RAP, IBR, ICR, PAYE and tiered Standard payments, forgiveness timing, the tax on forgiveness, and which plans a given loan book is excluded from with the federal rule that excludes it.

Against the contributing bar:

- **Reachable at a public URL** — yes; `initialize` over Streamable HTTP.
- **Usable by anyone** — yes, and with no signup. A sandbox key is one unauthenticated call:
  ```bash
  curl -X POST https://api.finology.tech/v1/keys/sandbox \
    -H 'Content-Type: application/json' -d '{"email":"you@example.com"}'
  ```
  100 calls/month, no card, no human in the loop. The key works as `X-Api-Key` or as `Authorization: Bearer`.
  The 401 itself names that call in its body, so an agent that arrives without a key can get one without asking anyone.
- **Not a per-user endpoint** — one URL for everyone.
- **Not behind a paywall** — the free sandbox tier is the same endpoint and the same tools.

What makes it worth a line: every answer carries the rule version it was computed under and citations to the primary source behind each constant, and is recorded before it is served. A missing input is refused rather than defaulted — an omitted income is an error, not an assumed zero.

No Glama connector badge yet; I'll add one once it's listed at glama.ai/mcp/connectors.

Following the `🤖🤖🤖` convention from CONTRIBUTING.md — prepared by an agent on behalf of the server's maintainer.
