### PR TITLE
Add NoClick remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.
+- [NoClick](https://www.noclick.com/mcp) `https://api.noclick.io/mcp`
+  [![NoClick MCP connector](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick)
+  🔐 - Build, run, and monitor workflows and background AI agents across connected apps.
 
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 


### PR DESCRIPTION
Adds NoClick under Workplace & Productivity, with its public Streamable HTTP endpoint, OAuth marker, and Glama connector badge. Its tools build, run, and monitor workflows and background AI agents across connected apps.

Moved from punkpeye/awesome-mcp-servers#13127 following the maintainer's split of hosted endpoints into this repository.

**Server:** [NoClick](https://www.noclick.com/mcp)
**Endpoint:** `https://api.noclick.io/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Validation: an unauthenticated initialize request returns HTTP 401 with a Bearer `WWW-Authenticate` challenge containing OAuth resource metadata, matching this repository's OAuth probe. The [Glama connector](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick) is ownership-verified and Healthy after authenticated introspection using a dedicated test account. The connector page and its score badge both return HTTP 200. The README change adds exactly one three-line entry, with an 81-character description.
