### PR TITLE
Add Promptguard (GLC MCP) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔒 <a name="security"></a>Security
 
+- [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) `https://mcp.glc-rag.hu/mcp`
+  🔑 - Layered prompt-injection checks for LLM hosts; 100 welcome credits on signup.
 - [Semgrep](https://semgrep.dev) `https://mcp.semgrep.ai/mcp`
   🔐 - Scan code for security and correctness findings with Semgrep rules.
 


### PR DESCRIPTION
## Summary
- Add [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) under **Security**
- Endpoint: `https://mcp.glc-rag.hu/mcp` (Streamable HTTP)
- Auth: 🔑 API token via public agent/human signup ([agent guide](https://mcp.glc-rag.hu/guide/agent)); new orgs get **100 welcome credits**
- Layered prompt-injection checks for LLM hosts (orchestrator-side); same MCP also exposes other modular tools after signup

## Test plan
- [x] Endpoint returns HTTP 401 without credentials (CI auth probe → 🔑)
- [x] With Bearer token, MCP `initialize` returns `serverInfo.name=glc-mcp-platform`
- [x] Entry alphabetical in Security (before Semgrep)
- [x] Description ≤120 chars and ends with a period


Made with [Cursor](https://cursor.com)