### PR TITLE
Add Aave to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 💰 <a name="finance"></a>Finance
 
+- [Aave](https://aave.com) `https://mcp.aave.com`
+  [![Aave MCP connector](https://glama.ai/mcp/connectors/com.aave.mcp/aave/badges/score.svg)](https://glama.ai/mcp/connectors/com.aave.mcp/aave)
+  🔓 - Aave V3 and V4 lending markets, rates, wallet positions, rewards, governance, and non-custodial transaction building.
 - [AgentWorld](https://agentworld.me) `https://agentworld.me/mcp`
   🔓 - Live AI agent economy on Base L2 — free reads of city, agent, and job data, plus paid x402 USDC tools for agent chat, leaderboard, and SolvScore credit scoring.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`


### PR DESCRIPTION
Resubmitting from punkpeye/awesome-mcp-servers#13287, which was closed with a pointer to this list.

Aave's official MCP server, maintained by Aave Labs. Streamable HTTP at `https://mcp.aave.com`, no authentication, so 🔓. A POST `initialize` to that URL returns the server card; `/mcp` is an alias for the same endpoint.

40 tools across Aave V3 and V4: lending markets and rates on every supported chain in one call, wallet positions and health factor, rewards, DAO governance, and transaction building. Non-custodial, so the `prepare_*` tools return an unsigned transaction or EIP-712 typed data for the user's own wallet to sign.

Glama connector badge included: com.aave.mcp/aave, ownership verified, TDQS A.

One entry added to Finance, alphabetically first.