### PR TITLE
Add Perspect (remote multi-persona AI debate server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
   [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.
+- [Perspect](https://tryperspect.com) `https://perspect-ai-backend.onrender.com/mcp`
+  [![Perspect MCP connector](https://glama.ai/mcp/connectors/com.tryperspect/perspect/badges/score.svg)](https://glama.ai/mcp/connectors/com.tryperspect/perspect)
+  🔑 - Convene a panel of expert AI personas to debate any decision from every side and return a synthesized briefing.
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   🔓 - Ethiopian calendar and date conversion.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.
 - [Perspect](https://tryperspect.com) `https://perspect-ai-backend.onrender.com/mcp`
   [![Perspect MCP connector](https://glama.ai/mcp/connectors/com.tryperspect/perspect/badges/score.svg)](https://glama.ai/mcp/connectors/com.tryperspect/perspect)
-  🔑 - Convene a panel of expert AI personas to debate any decision from every side and return a synthesized briefing.
+  🔓 - Convene a panel of expert AI personas to debate any decision from every side and return a synthesized briefing.
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   🔓 - Ethiopian calendar and date conversion.


### PR DESCRIPTION
Adds Perspect under Other Tools & Integrations.

What it does: convene a panel of expert AI personas that debate any topic, idea, or decision from conflicting angles, then return a synthesized briefing and a contradiction map of where they disagree.

Details:
- Endpoint: https://perspect-ai-backend.onrender.com/mcp (Streamable HTTP)
- Auth: 🔑 per-user token. The initialize handshake and tools/list are open, so the endpoint is introspectable anonymously; running a debate requires an Authorization Bearer token (or X-API-Key) from a Perspect Pro account at https://www.tryperspect.com/connect.
- Public sign-up, multi-tenant, single shared endpoint (not per-user URLs).
- Glama connector com.tryperspect/perspect is listed and rated A.
- Two tools: list_personas and run_debate.