### PR TITLE
Add GO AI Tools to Developer Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search the Cloudflare developer documentation.
 - [DeepWiki](https://deepwiki.com) `https://mcp.deepwiki.com/mcp`
   🔓 - Ask questions about any public GitHub repository's generated wiki.
+- [GO AI Tools](https://goaichat.app/mcp-tools) `https://goaichat.app/mcp-tools/mcp`
+  [![GO AI Tools MCP connector](https://glama.ai/mcp/connectors/app.goaichat/tools/badges/score.svg)](https://glama.ai/mcp/connectors/app.goaichat/tools)
+  🔓 - 31 deterministic tools: image conversion, EXIF stripping, App Store assets, colour maths.
 - [Globalping](https://globalping.io) `https://mcp.globalping.dev/mcp`
   🔐 - Run ping, traceroute, DNS, and HTTP checks from a global probe network.
 - [OpenRouter](https://openrouter.ai) `https://mcp.openrouter.ai/mcp`


### PR DESCRIPTION
Public remote MCP server, no authentication. 31 deterministic tools (image conversion, EXIF stripping, App Store assets, colour and layout maths, everyday calculators). Nothing here calls a model, which is why it can be free.

Moved here from awesome-mcp-servers #13986 at the maintainer's suggestion.

**Server:** GO AI Tools
**Endpoint:** `https://goaichat.app/mcp-tools/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Docs: https://goaichat.app/mcp-tools · Official registry: `app.goaichat/tools` · Source: https://github.com/Feghal/goai_tools_mcp

This PR was drafted with AI assistance on my behalf; I've reviewed the diff before submitting.