### PR TITLE
Add ADSBiq hosted aircraft MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🚆 <a name="travel--transportation"></a>Travel & Transportation
 
 - [ADSBiq](https://adsbiq.com/api/other/mcp) `https://adsbiq.com/mcp`
-  🔑 - Look up live aircraft, search nearby traffic, and retrieve aggregate ADS-B network statistics.
+  🔓 - Look up live aircraft, search nearby traffic, and retrieve aggregate ADS-B network statistics.
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🚆 <a name="travel--transportation"></a>Travel & Transportation
 
 - [ADSBiq](https://adsbiq.com/api/other/mcp) `https://adsbiq.com/mcp`
+  [![ADSBiq MCP connector](https://glama.ai/mcp/connectors/com.adsbiq/adsbiq/badges/score.svg)](https://glama.ai/mcp/connectors/com.adsbiq/adsbiq)
   🔓 - Look up live aircraft, search nearby traffic, and retrieve aggregate ADS-B network statistics.
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)

--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🚆 <a name="travel--transportation"></a>Travel & Transportation
 
+- [ADSBiq](https://adsbiq.com/api/other/mcp) `https://adsbiq.com/mcp`
+  🔑 - Look up live aircraft, search nearby traffic, and retrieve aggregate ADS-B network statistics.
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.


### PR DESCRIPTION
**Server:** [ADSBiq](https://adsbiq.com/api/other/mcp)
**Endpoint:** `https://adsbiq.com/mcp`

Replacement for https://github.com/punkpeye/awesome-mcp-servers/pull/12674, following @punkpeye's request to move hosted servers to this list.

Adds ADSBiq under Travel & Transportation: bounded, read-only single-aircraft lookup, nearby aircraft search (maximum 50 aircraft within 250 nm), and aggregate network statistics via Streamable HTTP.

### Hosted verification - 2026-09-08

Public trial/free MCP access is now deployed. No API key is required; optional feeder/publisher credentials grant higher limits. From an external non-feeder client, initialize, tools/list (all three tools), and network_stats each returned HTTP 200. An immediate second tool call returned HTTP 429 with Retry-After: 20, confirming the trial limiter. Discovery does not consume tool quotas. The existing free tier uses a five-minute call interval, and daily byte quotas are enforced. All 26 local MCP regression tests pass.

The earlier Cloudflare Error 1010 occurred with Python's default client signature. Verification with an identified ADSBiq deployment-check client succeeds; no Cloudflare rules were changed.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] No-auth marker matches verified public access

Glama already lists the remote connector at https://glama.ai/mcp/connectors/com.adsbiq/adsbiq (a new submission was prevented as a duplicate). Added its actual connector badge, verified to return HTTP 200 and SVG content. This is separate from the local-server listing.

Glama still displays an unhealthy result from its pre-deployment check (2026-09-08 15:52 UTC). The hosted verification above was performed after deployment; Glama's next health check is pending. We are not claiming the cached badge has a passing health score yet.
