### PR TITLE
Add Elicitly 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ## Servers
 
 * 🔗 - [Aggregators](#aggregators)
+* 🤝 - [Agreements & Coordination](#agreements--coordination)
 * 🎨 - [Art & Design](#art--design)
 * 🌐 - [Browser Automation](#browser-automation)
 * ☁️ - [Cloud Platforms](#cloud-platforms)
@@ -108,6 +109,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
   [![Zapier MCP connector](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier/badges/score.svg)](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier)
   🔐 - Run your Zapier actions across thousands of connected apps as MCP tools.
+
+### 🤝 <a name="agreements--coordination"></a>Agreements & Coordination
+
+- [Elicitly](https://www.elicitly.ai) `https://mcp.elicitly.ai/mcp`
+  [![Elicitly MCP connector](https://glama.ai/mcp/connectors/ai.elicitly/pro/badges/score.svg)](https://glama.ai/mcp/connectors/ai.elicitly/pro)
+  🔐 - Human-in-the-loop for AI agents: confirmations, forms, and durable approvals that reach any device, with an audit trail.
 
 ### 🎨 <a name="art--design"></a>Art & Design
 


### PR DESCRIPTION
Adds [Elicitly](https://www.elicitly.ai) — human-in-the-loop for AI agents over MCP elicitation: confirmations, typed forms, and durable approvals with a hosted review page that reaches any device, plus an audit trail.

- Endpoint: `https://mcp.elicitly.ai/mcp` (Streamable HTTP, answers `initialize`)
- Auth: 🔐 OAuth (public sign-up at https://app.elicitly.ai/signup — free during Early Access)
- Glama connector badge included: [`ai.elicitly/pro`](https://glama.ai/mcp/connectors/ai.elicitly/pro) (claimed, health-checked)
- Official MCP Registry: `ai.elicitly/pro`

This adds a new **Agreements & Coordination** category (index + section, alphabetical), mirroring the same category on awesome-mcp-servers where the local edition lives ([#14007](https://github.com/punkpeye/awesome-mcp-servers/pull/14007) — split from punkpeye/awesome-mcp-servers#12254 per the remote/local reorganization). Happy to move it under an existing category if you'd rather not add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQaQ9sjfSovkcXZipdm6yJ