### PR TITLE
Add kanari (real-time wildfire ignitions) to Environment 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ambee](https://ambeedata.com) `https://api-mcp-server.ambeedata.com/mcp`
   [![Ambee MCP connector](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee/badges/score.svg)](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee)
   🔓 - Weather, air quality, pollen, and other environmental data.
+- [kanari](https://kanari.io) `https://kanari.io/api/mcp`
+  [![kanari MCP connector](https://glama.ai/mcp/connectors/io.github.vria-consulting/kanari-wildfires/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.vria-consulting/kanari-wildfires)
+  🔓 - Near real-time wildfire ignitions worldwide: active fires, archive search, stats, live water bombers, earliness cases.
 
 ### 📂 <a name="file-storage"></a>File Storage
 


### PR DESCRIPTION
Adds **kanari**, a free near-real-time world map of wildfire ignitions, under **Environment** (alphabetical, after Ambee).

- Endpoint: `https://kanari.io/api/mcp` (Streamable HTTP, no key, no account, read-only)
- Glama connector badge: https://glama.ai/mcp/connectors/io.github.vria-consulting/kanari-wildfires
- Tools: active_fires, fire_archive_search, fire_details, wildfire_stats, firefighting_aircraft, earliness_cases
- Data: NASA FIRMS/VIIRS, GOES, Meteosat MTG hotspots + AI-verified witness reports; open data CC BY 4.0

Follow-up of punkpeye/awesome-mcp-servers#13636, closed when remote servers moved to this list. Opened with an agent on behalf of the author.