### PR TITLE
Add AINSOF (Multimedia) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎥 <a name="multimedia"></a>Multimedia
 
+- [AINSOF](https://ainsof.io) `https://mcp.ainsof.io`
+  [![AINSOF MCP connector](https://glama.ai/mcp/connectors/io.ainsof.mcp/ainsof/badges/score.svg)](https://glama.ai/mcp/connectors/io.ainsof.mcp/ainsof)
+  🔓 - Search a licensed production-music catalogue by brief or reference link, and score video to picture.
 - [invideo](https://invideo.io) `https://mcp.invideo.io/mcp`
   🔓 - Generate and edit videos from a prompt.
 


### PR DESCRIPTION
Adds **AINSOF** under **Multimedia** — the official remote MCP server of [ainsof.io](https://ainsof.io), a curated catalogue of original human-made production music built for sync.

Moved here from [awesome-mcp-servers#11678](https://github.com/punkpeye/awesome-mcp-servers/pull/11678), which was closed with a pointer to this list. This is exactly the right home: the score requirement that blocked the old PR was a server-record release, which a hosted endpoint cannot produce — and this list reads the connector badge instead, where AINSOF is already graded.

| | |
| --- | --- |
| Endpoint | `https://mcp.ainsof.io` |
| Transport | Streamable HTTP |
| Auth | none — 🔓, free tier 300 calls/day |
| Tools | 12 |
| Connector | [io.ainsof.mcp/ainsof](https://glama.ai/mcp/connectors/io.ainsof.mcp/ainsof) — `Healthy`, every tool graded **A** |

**What it does:** search the catalogue by a written brief or by a reference link — paste a Spotify / YouTube / Apple Music URL and the server listens to the record and matches by sound — hear full watermarked previews, score a video straight to picture, and pull versions, stems, sound effects and cue-sheet data for clearance. Every cue is written, performed and produced by human composers; nothing in the catalogue is AI-generated.

Verifiable without a key:

```bash
curl -s -X POST https://mcp.ainsof.io \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
```

Checked against CONTRIBUTING before opening: repository starred, alphabetical within Multimedia, endpoint in backticks, connector badge on its own line, 🔓 marker, description one sentence at 100 characters. Also listed in the official MCP registry as `io.ainsof/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
