### PR TITLE
Add verified Nexez Glama connector badge 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
+  [![Nexez MCP connector](https://glama.ai/mcp/connectors/ai.nexez/commerce/badges/score.svg)](https://glama.ai/mcp/connectors/ai.nexez/commerce)
 
 ### 🌳 <a name="environment"></a>Environment
 


### PR DESCRIPTION
Follow-up to merged #51: Nexez already has a live Glama connector. Adds its verified score badge to the existing entry without creating a duplicate. Connector: https://glama.ai/mcp/connectors/ai.nexez/commerce . Badge URL returns HTTP 200 with SVG content. Endpoint and description are unchanged.