### PR TITLE
Add docs2mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
   [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
   🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.
+- [docs2mcp](https://docs2mcp.com) `https://mcp.docs2mcp.com/mcp`
+  [![docs2mcp MCP connector](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp)
+  🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.


### PR DESCRIPTION
Adds **docs2mcp** under 🧠 Knowledge & Memory.

Moved here from punkpeye/awesome-mcp-servers#13785, which you closed in favour of this list.

**What it does:** you upload your own PDFs and documents, and query them from any MCP client. Every result carries a link that opens the source document at the exact page and region the text came from, so an answer can be checked against the original rather than taken on trust.

**Endpoint:** `https://mcp.docs2mcp.com/mcp` — remote Streamable HTTP, OAuth 2.1, nothing to install.

**Auth marker:** 🔐. An unauthenticated `initialize` returns `401` with an RFC 9728 `WWW-Authenticate` header pointing at the protected-resource metadata, the same as the other OAuth entries on the list.

**Glama connector badge:** [com.docs2mcp/docs2mcp](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp), claimed via DNS challenge. The badge SVG resolves.

Repo is starred. Entry is one alphabetical insertion, no other lines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01969TpEoXQMUPXMCqcmYnkY


<!-- re-checked after the Cloudflare fix: mcp.docs2mcp.com is DNS-only, the endpoint returns 401 with an RFC 9728 WWW-Authenticate header from any IP -->
