### PR TITLE
Add The Undesirables TCG Oracle (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Sector Pulse](https://sector-pulse.app) `https://sector-pulse.app/api/mcp`
   [![Sector Pulse MCP connector](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse)
   🔓 - Live US sector rotation: 30 sector baskets ranked every session, versioned rosters, daily record; history needs a key.
+- [The Undesirables TCG Oracle](https://the-undesirables.com) `https://mcp.the-undesirables.com/mcp`
+  [![The Undesirables TCG Oracle MCP connector](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server)
+  🔓 - On-chain TCG price oracle: 456K+ cards, calibrated risk forecasts, AI grading, loan terms; free reads, x402 paid tools.
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`
   [![Vantage MCP connector](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage)
   🔐 - Ask questions about cloud cost and usage data.


### PR DESCRIPTION
Hosted MCP endpoint, no auth, Streamable HTTP (legacy SSE also served): `https://mcp.the-undesirables.com/mcp`

Financial intelligence for the trading-card market: 456K+ products across 25+ games, conformal-calibrated 30-day risk forecasts with a public accuracy scorecard, AI card grading, card-collateral loan terms, fantasy souls league. 22 tools; free tools answer directly, paid tools return x402 terms (USDC on Base/Solana, USDG on Robinhood Chain). Glama connector: io.github.sailorpepe/undesirables-mcp-server.

One server per PR as requested in #58; LitVM TCG Oracle is submitted separately.