### PR TITLE
Add Agent Chef (Food & Dining) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🍽️ <a name="food--dining"></a>Food & Dining
 
+- [Agent Chef](https://agentchef.net) `https://agentchef.net/mcp`
+  [![Agent Chef MCP connector](https://glama.ai/mcp/connectors/net.agentchef/agent-chef/badges/score.svg)](https://glama.ai/mcp/connectors/net.agentchef/agent-chef)
+  🔐 - Weekly family dinner ballot: propose ten recipes, household votes, top three win, grocery list minus the pantry.
 - [HeyYumi](https://heyyumi.ai) `https://mcp.heyyumi.ai/mcp`
   [![HeyYumi MCP connector](https://glama.ai/mcp/connectors/ai.heyyumi/heyyumi/badges/score.svg)](https://glama.ai/mcp/connectors/ai.heyyumi/heyyumi)
   🔐 - Search verified Korean restaurants and bars by filters, then request a table booking in chat.


### PR DESCRIPTION
Adds **Agent Chef** under Food & Dining.

- Endpoint: `https://agentchef.net/mcp` (Streamable HTTP). Answers `initialize` without credentials; `tools/list` is available without credentials via `?introspect=1`.
- Auth: OAuth 2.1 (dynamic client registration, PKCE, CIMD), API keys also accepted. Public sign-up with a free trial.
- Glama connector: https://glama.ai/mcp/connectors/net.agentchef/agent-chef (rated A, 34 tools).
- What it does: family meal planning run by the user's own agent. Each week the agent proposes ten dinners, household members vote from personal links, the top three win, and the server builds a grocery list minus the pantry. The agent never places orders.

Moved here from punkpeye/awesome-mcp-servers#13793 at the maintainer's request. Repo starred.