### PR TITLE
Add AI Design Blueprint 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Agentic Atlas](https://agentic-atlas.dev/) `https://agentic-atlas.dev/mcp/`
   [![Agentic Atlas MCP connector](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas/badges/score.svg)](https://glama.ai/mcp/connectors/dev.agentic-atlas/atlas)
   🔓 - Give AI agents a field guide to building better agents, with design patterns, tradeoffs, and decision guidance.
+- [AI Design Blueprint](https://aidesignblueprint.com) `https://aidesignblueprint.com/mcp`
+  [![AI Design Blueprint MCP connector](https://glama.ai/mcp/connectors/com.aidesignblueprint/blueprint/badges/score.svg)](https://glama.ai/mcp/connectors/com.aidesignblueprint/blueprint)
+  🔓 - Search 10 principles, examples and guides with 12 public tools; spec, architecture and UI validators on Pro/Teams.
 - [Astro Docs](https://astro.build) `https://mcp.docs.astro.build/mcp`
   🔓 - Search the Astro documentation.
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`


### PR DESCRIPTION
Adds AI Design Blueprint, a hosted MCP server for agentic design doctrine, under Developer Tools.

- Endpoint: `https://aidesignblueprint.com/mcp` (Streamable HTTP; anonymous `initialize` and `tools/list` succeed).
- 12 public tools with no authentication (principles, clusters, examples, guides, assets, feedback), so the entry carries 🔓. The spec, architecture and UI validators are Pro/Teams tools and the description says so.
- Glama connector: `com.aidesignblueprint/blueprint`. Official registry name: `com.aidesignblueprint/blueprint`.
- Follows punkpeye/awesome-mcp-servers#10308, closed with the note that hosted servers belong in this list. The existing awesome-mcp-servers entry from #5337 is left as is.

Repository starred as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGw9XUFDCLXukteJCYZy1G