### PR TITLE
Add Realask (verified answers from US local businesses, by phone) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
   [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
   🔓 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
+- [Realask](https://realask.net) `https://realask.net/mcp`
+  [![Realask MCP connector](https://glama.ai/mcp/connectors/io.github.danelas/realask/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.danelas/realask)
+  🔓 - Verify facts about US local businesses by phone — stock, all-in price, availability — as typed answers with evidence.
 - [Simplescraper](https://simplescraper.io) `https://mcp.simplescraper.io/mcp`
   🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`


### PR DESCRIPTION
Reopening [punkpeye/awesome-mcp-servers#13958](https://github.com/punkpeye/awesome-mcp-servers/pull/13958) here, as suggested — Realask is a remote server, so it belongs on this list.

Adds **[Realask](https://realask.net)** to **Search & Data Extraction**, alphabetically between `GovAuctions.app` and `Simplescraper`.

Realask answers questions about US local businesses that the web doesn't have or has stale — today's stock, a real all-in price, same-day availability, an edge-case capability, a policy exception, the current wait — by calling the business and returning typed facts with evidence, a timestamp, a confidence score, and an explicit list of what it could not verify. It returns the answer, not a transcript.

- Endpoint: `https://realask.net/mcp`, Streamable HTTP, answers `initialize` anonymously — hence 🔓
- Glama connector badge included: [`io.github.danelas/realask`](https://glama.ai/mcp/connectors/io.github.danelas/realask), currently rated A
- Listed in the official MCP registry as `io.github.danelas/realask`
- Quoting is free; jobs are paid per call in USDC on Base via [x402](https://x402.org)

Repo starred. One entry added, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
