### PR TITLE
Add Hubris to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔗 <a name="aggregators"></a>Aggregators
 
+- [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
+  [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
+  🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
   [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)
   🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.


### PR DESCRIPTION
**Hubris** — a hosted, OpenAI-compatible LLM gateway for the Russian market: one endpoint over 500+ models from every major vendor, billed in rubles to a prepaid balance. The MCP server exposes the model catalogue with ruble pricing, the account balance, and chat completions with parity to `/v1/chat/completions`.

Moved here from awesome-mcp-servers #13643 per the close notice.

**Category.** Aggregators, not Finance where the old entry sat — the server aggregates models behind one paid endpoint (the same shape as TaskFuel) and has nothing to do with financial data.

**Auth marker.** 🔐. The endpoint answers an unauthenticated `initialize` with 401 plus `WWW-Authenticate: Bearer … resource_metadata=…`, which is what `check-submission.yml` maps to OAuth. Both OAuth and API keys work; the Glama connector shows OAuth working in-app.

**Badge.** Connector `pw.hubris.api/hubris` — claimed, healthy, rated B, 5 tools. URL returns 200.

Entry is 3 lines in CRLF like the rest of the file; description is 117 characters. Repository starred.