### PR TITLE
Add Shingou to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Live US sector rotation: 30 sector baskets ranked every session, versioned rosters, daily record; history needs a key.
 - [Shingou](https://shingou.io) `https://api.shingou.io/mcp`
   [![Shingou MCP connector](https://glama.ai/mcp/connectors/io.shingou/sentiment/badges/score.svg)](https://glama.ai/mcp/connectors/io.shingou/sentiment)
-  🔑 - Hourly news sentiment and typed market events for 30 crypto pairs, with source links on every signal and a published hash for every hour of history.
+  🔓 - Hourly news sentiment and typed market events for 30 crypto pairs, source links on every signal, a published hash for every hour of history; data tools need a free key.
 - [The Undesirables TCG Oracle](https://the-undesirables.com) `https://mcp.the-undesirables.com/mcp`
   [![The Undesirables TCG Oracle MCP connector](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server)
   🔓 - On-chain TCG price oracle: 456K+ cards, calibrated risk forecasts, AI grading, loan terms; free reads, x402 paid tools.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Sector Pulse](https://sector-pulse.app) `https://sector-pulse.app/api/mcp`
   [![Sector Pulse MCP connector](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse)
   🔓 - Live US sector rotation: 30 sector baskets ranked every session, versioned rosters, daily record; history needs a key.
+- [Shingou](https://shingou.io) `https://api.shingou.io/mcp`
+  [![Shingou MCP connector](https://glama.ai/mcp/connectors/io.shingou/sentiment/badges/score.svg)](https://glama.ai/mcp/connectors/io.shingou/sentiment)
+  🔑 - Hourly news sentiment and typed market events for 30 crypto pairs, with source links on every signal and a published hash for every hour of history.
 - [The Undesirables TCG Oracle](https://the-undesirables.com) `https://mcp.the-undesirables.com/mcp`
   [![The Undesirables TCG Oracle MCP connector](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server)
   🔓 - On-chain TCG price oracle: 456K+ cards, calibrated risk forecasts, AI grading, loan terms; free reads, x402 paid tools.


### PR DESCRIPTION
Adds Shingou under Finance.

Endpoint: `https://api.shingou.io/mcp`
Transport: Streamable HTTP, stateless.
Glama connector: `io.shingou/sentiment`.

One thing worth flagging so the check does not look like a mistake. The entry says 🔑 and your probe will report 🔓. The handshake is open on purpose: `initialize`, `tools/list` and `get_symbols` all answer without credentials, so a client can see the four tools before it holds a key. The three data tools return 401 without one.

I went with 🔑 because that is what a reader needs before they paste the URL. If you would rather the marker match the probe I will change it, though a reader who sees 🔓 will hit a 401 on their first data call.

Free keys are self-serve at https://shingou.io/dashboard. No card.
