### PR TITLE
Add Floot 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Cloudflare Bindings](https://developers.cloudflare.com/agents/model-context-protocol/) `https://bindings.mcp.cloudflare.com/mcp`
   🔐 - Build on Workers KV, R2, D1, and other Cloudflare bindings.
+- [Floot](https://floot.com) `https://mcp.floot.com/mcp`
+  [![Floot MCP connector](https://glama.ai/mcp/connectors/com.floot/floot/badges/score.svg)](https://glama.ai/mcp/connectors/com.floot/floot)
+  🔐 - Write React pages and serverless endpoints, provision Postgres and auth, run SQL, read logs, and publish to a live URL.
 - [Heroku](https://heroku.com) `https://mcp.heroku.com/mcp`
   🔐 - Manage Heroku apps, dynos, add-ons, and logs.
 - [Netlify](https://netlify.com) `https://netlify-mcp.netlify.app/mcp`


### PR DESCRIPTION
Moving this over from punkpeye/awesome-mcp-servers#11976, which was closed with a pointer to this list. Floot is a hosted remote server, so it belongs here.

**Floot** is a hosting platform for full-stack web and mobile apps that your own coding agent builds directly over MCP — React/TypeScript pages and serverless endpoints, with Postgres, auth, email and push provisioning, typechecks, SQL, logs, and publishing to a live URL with custom domains.

Floot is not itself an agent. The server exposes plain file and infrastructure tools, so whichever MCP client is connected does the coding on the user's own AI subscription — there is no in-house agent proxying prompts and no per-token platform credits.

- Endpoint: `https://mcp.floot.com/mcp` (Streamable HTTP, OAuth 2.1 → 🔐)
- Homepage: https://floot.com
- Connect / docs: https://floot.com/integrations/mcp
- Glama connector: https://glama.ai/mcp/connectors/com.floot/floot

Checklist:
- Public URL, answers `initialize` unauthenticated and advertises OAuth via `WWW-Authenticate`.
- Public sign-up, single shared endpoint — no per-user URL.
- Placed alphabetically in Cloud Platforms between Cloudflare Bindings and Heroku.
- Description is one sentence, 119 characters.
- Repo starred.

Official submission — I work on Floot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)