### PR TITLE
Re-add Perspect (accidentally removed after merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
   [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.
+- [Perspect](https://tryperspect.com) `https://perspect-ai-backend.onrender.com/mcp`
+  [![Perspect MCP connector](https://glama.ai/mcp/connectors/com.tryperspect/perspect/badges/score.svg)](https://glama.ai/mcp/connectors/com.tryperspect/perspect)
+  🔓 - Convene a panel of expert AI personas to debate any decision from every side; running a debate needs a Pro key.
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   🔓 - Ethiopian calendar and date conversion.


### PR DESCRIPTION
Perspect was added and merged earlier today in #48, but it was accidentally removed a few minutes later. Comparing the #48 merge commit (ec8669f) to current main shows three entries dropped together (kanari, docs2mcp, and Perspect), which looks like collateral from a stale-base merge rather than an intentional removal.

Re-adding the same entry under Other Tools & Integrations. Per the maintainer's recent formatting (open marker plus the key requirement noted in the description), I kept the 🔓 marker (the endpoint answers initialize anonymously) and noted that running a debate needs a key.

- Endpoint: https://perspect-ai-backend.onrender.com/mcp (Streamable HTTP)
- Glama connector com.tryperspect/perspect is listed and rated A.
- Discovery (initialize, tools/list) is anonymous; running a debate uses a per-user token from a Perspect Pro account.