### PR TITLE
Add Capacitor, Capawesome and Ionic Framework MCP servers 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Trigger and inspect Bitrise CI builds and artifacts.
 - [Capacitor MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/capacitor/) `https://capacitor-mcp.capawesome.io/mcp`
   [![Capacitor MCP connector](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp)
-  🔓 - Unofficial: search the Capacitor docs for v6 to next, read pages, and list official and community plugins.
+  🔓 - Unofficial: search the Capacitor docs (v6+), read pages, and list official and community plugins.
 - [Capawesome MCP Server](https://capawesome.io/docs/ai/mcp/capawesome/) `https://mcp.capawesome.io/mcp`
   [![Capawesome MCP connector](https://glama.ai/mcp/connectors/io.capawesome/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/mcp)
   🔓 - Search the Capawesome docs and blog; an API token adds the Capawesome Cloud management tools.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`
   [![Bitrise MCP connector](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp)
   🔐 - Trigger and inspect Bitrise CI builds and artifacts.
+- [Capacitor MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/capacitor/) `https://capacitor-mcp.capawesome.io/mcp`
+  [![Capacitor MCP connector](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp)
+  🔓 - Unofficial: search the Capacitor docs for v6 to next, read pages, and list official and community plugins.
+- [Capawesome MCP Server](https://capawesome.io/docs/ai/mcp/capawesome/) `https://mcp.capawesome.io/mcp`
+  [![Capawesome MCP connector](https://glama.ai/mcp/connectors/io.capawesome/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/mcp)
+  🔓 - Search the Capawesome docs and blog; an API token adds the Capawesome Cloud management tools.
 - [Cloudflare Docs](https://developers.cloudflare.com) `https://docs.mcp.cloudflare.com/mcp`
   🔓 - Search the Cloudflare developer documentation.
 - [DeepWiki](https://deepwiki.com) `https://mcp.deepwiki.com/mcp`
@@ -226,6 +232,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - 31 deterministic tools: image conversion, EXIF stripping, App Store assets, colour maths.
 - [Globalping](https://globalping.io) `https://mcp.globalping.dev/mcp`
   🔐 - Run ping, traceroute, DNS, and HTTP checks from a global probe network.
+- [Ionic Framework MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/ionic-framework/) `https://ionic-framework-mcp.capawesome.io/mcp`
+  [![Ionic Framework MCP connector](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp)
+  🔓 - Unofficial: search the Ionic Framework docs for v8 and v9, with the component API and usage examples.
 - [OpenRouter](https://openrouter.ai) `https://mcp.openrouter.ai/mcp`
   [![OpenRouter MCP connector](https://glama.ai/mcp/connectors/ai.openrouter.mcp/open-router/badges/score.svg)](https://glama.ai/mcp/connectors/ai.openrouter.mcp/open-router)
   🔐 - Look up OpenRouter model metadata and pricing, and run completions.


### PR DESCRIPTION
Three hosted MCP servers by Capawesome, all under Developer Tools:

**Server:** Capacitor MCP Server by Capawesome (unofficial)
**Endpoint:** `https://capacitor-mcp.capawesome.io/mcp`

**Server:** Capawesome MCP Server
**Endpoint:** `https://mcp.capawesome.io/mcp`

**Server:** Ionic Framework MCP Server by Capawesome (unofficial)
**Endpoint:** `https://ionic-framework-mcp.capawesome.io/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

All three answer `initialize` without authentication. The Capawesome server additionally accepts a Capawesome Cloud API token as a bearer header, which registers its Cloud management tools; the documentation tools need none. Resubmitted from awesome-mcp-servers #13978, #13979 and #13980 per the maintainer's note.