### PR TITLE
Add ToolTrace remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`
   🔐 - Web search and content extraction built for agents.
+- [ToolTrace](https://tooltrace.io/mcp) `https://mcp.tooltrace.io/mcp`
+  🔑 - Scrape pages to Markdown, extract metadata and JSON-LD, audit on-page SEO, and check XML sitemaps.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds ToolTrace to Search & Data Extraction, alphabetically after Tavily.

Hosted Streamable HTTP endpoint for the ToolTrace web data APIs: scrape pages
to Markdown, extract metadata and JSON-LD, audit on-page SEO, detect tech
stacks, and check XML sitemaps.

- Endpoint: `https://mcp.tooltrace.io/mcp`
- Auth: API key via `Authorization: Bearer` (🔑)
- Public sign-up, free tier, no card required
- Also listed in the official MCP registry as `io.tooltrace/mcp-server`
