### PR TITLE
Re-add docs2mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
   [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
   🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.
+- [docs2mcp](https://docs2mcp.com) `https://mcp.docs2mcp.com/mcp`
+  [![docs2mcp MCP connector](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp)
+  🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.


### PR DESCRIPTION
Re-adds **docs2mcp** under 🧠 Knowledge & Memory. Same three lines you merged in #59 — nothing about the entry has changed.

It was removed by accident. [`1d3dce4`](https://github.com/punkpeye/awesome-remote-mcp-servers/commit/1d3dce4508e1f5e5063adbfe7ac4428993d12af8) ("Add AlphaPipeline to Finance") was built on a fork taken before several merges, so it **added 3 lines and deleted 17**, reverting every entry added after that fork point.

Four of those six are still missing from `main`:

- **Python Code Validator** — 🔓 Search & Data Extraction
- **AMZ Vault** — 🔐 E-Commerce
- **kanari** — 🔓 Environment
- **docs2mcp** — 🔐 Knowledge & Memory (this PR)

Perspect was restored by its author in #71. AlphaPipeline itself is fine. I have only re-added my own line here — happy to restore the other three in this PR if you would rather have one commit, or leave them to their authors.

Might be worth having the check flag a PR whose diff deletes lines it did not add. It would have caught this one before the merge.

One note on my own entry, since the auth check flagged it on #59: that was real and is fixed. `mcp.docs2mcp.com` was proxied through Cloudflare with Bot Fight Mode on, so a probe from a datacenter IP got a `403` challenge page instead of the RFC 9728 `401`. The record is DNS-only now, and a request from a GitHub Actions runner returns:

```
status: 401
www-authenticate: Bearer realm="docs2mcp", resource_metadata="https://mcp.docs2mcp.com/.well-known/oauth-protected-resource/mcp"
cf-mitigated: null
```

So 🔐 is correct and the check should agree.
