### PR TITLE
Add Capacitor MCP Server by Capawesome 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`
   [![Bitrise MCP connector](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp)
   🔐 - Trigger and inspect Bitrise CI builds and artifacts.
+- [Capacitor MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/capacitor/) `https://capacitor-mcp.capawesome.io/mcp`
+  [![Capacitor MCP connector](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp)
+  🔓 - Unofficial: search the Capacitor docs for v6 and later, read pages, and list official and community plugins.
 - [Cloudflare Docs](https://developers.cloudflare.com) `https://docs.mcp.cloudflare.com/mcp`
   🔓 - Search the Cloudflare developer documentation.
 - [DeepWiki](https://deepwiki.com) `https://mcp.deepwiki.com/mcp`


### PR DESCRIPTION
**Server:** Capacitor MCP Server by Capawesome
**Endpoint:** `https:https`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

The official Capawesome MCP server. The documentation tools need no token; a Capawesome Cloud API token as bearer header registers the Cloud management tools. Resubmitted from #72 as one server per PR.