### PR TITLE
Add Razi Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search and fetch verified KiCad parts (symbol, footprint, 3D model) for AI-assisted PCB design — 21k+ parts, CC-BY-4.0, no account needed.
 - [Postman](https://postman.com) `https://mcp.postman.com/mcp`
   🔐 - Work with Postman collections, environments, and APIs.
+- [Razi Tools](https://www.razi.pro/developer) `https://www.razi.pro/api/mcp`
+  [![Razi Tools MCP connector](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools)
+  🔓 - 28 file and text tools: merge, split and compress PDFs, OCR, image compression, SQL, QR codes, JWTs and mock data.
 - [UI Verify](https://uiverify.ai) `https://uiverify.ai/api/mcp`
   [![UI Verify MCP connector](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify/badges/score.svg)](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify)
   🔓 - Audit a web page for accessibility and layout issues.


### PR DESCRIPTION
Moving this over from punkpeye/awesome-mcp-servers#13969 — closed there with a pointer to this list. Repo starred.

`https://www.razi.pro/api/mcp` — Streamable HTTP, JSON-RPC 2.0 over POST, protocol versions 2025-06-18 / 2025-03-26 / 2024-11-05. No signup: anonymous calls are rate limited, and a free key raises the limit. Discovery at `https://www.razi.pro/.well-known/mcp.json`, docs at https://www.razi.pro/developer.

One thing worth calling out: `tools/list` only advertises tools that genuinely execute server-side. The site has browser-only tools (WASM background removal, WebRTC file transfer, canvas work) and those are deliberately **not** listed, because a tool a model cannot actually run just costs it a turn to find out.

The same tools are also served as five domain-scoped endpoints — `/documents`, `/media`, `/web`, `/text`, `/dev` — each answering `initialize`, for agents that only work in one area and shouldn't have to read 28 tool descriptions. I've left them out of this PR to keep it to one line; happy to add them in a follow-up if you'd rather have them listed.