### PR TITLE
Add AfterLaunch (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎯 <a name="marketing"></a>Marketing
 
+- [AfterLaunch](https://afterlaunch.io) `https://afterlaunch.io/api/mcp`
+  [![AfterLaunch MCP connector](https://glama.ai/mcp/connectors/io.afterlaunch/agentic-growth-marketing/badges/score.svg)](https://glama.ai/mcp/connectors/io.afterlaunch/agentic-growth-marketing)
+  🔓 - AI answer visibility, SEO and a ranked backlog of growth moves as agent tools; tool calls need an AfterLaunch account.
 - [BizIntel](https://mcp-bizintel-production.up.railway.app) `https://mcp-bizintel-production.up.railway.app/mcp`
   [![BizIntel MCP connector](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel)
   🔓 - Audit websites, score local-business leads, detect technology stacks, and find businesses missing websites or booking systems.


### PR DESCRIPTION
Adds [AfterLaunch](https://afterlaunch.io) to the Marketing section, as requested when punkpeye/awesome-mcp-servers#11221 was closed for being a remote server.

AfterLaunch is a hosted MCP server that turns growth marketing into agent tools: read AI answer visibility across ChatGPT, Gemini, Perplexity and Google AI Overviews, pull a ranked backlog of growth moves, draft the deliverables and ship them. Official vendor implementation, listed in the MCP registry as `io.afterlaunch/agentic-growth-marketing`.

- Endpoint: `https://afterlaunch.io/api/mcp`, Streamable HTTP. It answers `initialize` and `tools/list` anonymously; tool calls need a signed-in account.
- Marker is 🔓 because the endpoint answers the handshake anonymously, matching what CI infers. Tool calls need an account, via OAuth (dynamic client registration + PKCE) or an API key as a bearer token; the description says so.
- Glama connector badge points at the live connector (`io.afterlaunch/agentic-growth-marketing`), which is rated A.
- Alphabetical placement within Marketing.
