### PR TITLE
Add Malwagon to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔒 <a name="security"></a>Security
 
+- [Malwagon](https://malwagon.com) `https://malwagon.com/mcp`
+  🔑 - Detonate files and URLs in a sandbox, then search the reports and indicators.
 - [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) `https://mcp.glc-rag.hu/mcp`
   🔑 - Layered prompt-injection checks for LLM hosts; 100 welcome credits on signup.
 - [Semgrep](https://semgrep.dev) `https://mcp.semgrep.ai/mcp`


### PR DESCRIPTION
Adds [Malwagon](https://malwagon.com) to the Security section.

It is a hosted malware analysis sandbox. The MCP server exposes five tools: look up a SHA-256, submit a scan, poll it, read the derived report, and search for an indicator (IP, domain, URL, mutex, registry key, hash, JA3/JA4).

Against the contribution rules:

- Remote and provider-hosted, one fixed endpoint for everyone at `https://malwagon.com/mcp`, not a per-user URL.
- Public sign-up, no waitlist and no sales call. A free tier issues tokens.
- `initialize` is answered without a credential, so the CI handshake check passes. Verified across the four handshake revisions listed in the spec as well as a client that sends no `MCP-Protocol-Version` header at all.
- `tools/list` is also public, so the catalogue can be read before anyone has a token. Tool calls need the bearer token, hence the key marker.
- Repository starred.

Alphabetical, before Promptguard. Description is 77 characters.

Disclosure: I work on Malwagon.