### PR TITLE
Add Katto (AI video clipper) to Multimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [invideo](https://invideo.io) `https://mcp.invideo.io/mcp`
   🔓 - Generate and edit videos from a prompt.
+- [Katto](https://katto.tech) `https://mcp.katto.tech/mcp`
+  🔐 - Turn long videos, podcasts and Twitch VODs into scored, captioned, vertical 9:16 clips.
 
 ### 💳 <a name="payments"></a>Payments
 


### PR DESCRIPTION
Moving here from awesome-mcp-servers (#13956) per the maintainer's note that hosted/remote servers belong in this list.

**Katto** — official hosted MCP server for the Katto AI video clipper. Turns long videos, podcasts and Twitch VODs into scored, captioned, vertical 9:16 clips, drivable from Claude/Cursor/ChatGPT.

- Endpoint: `https://mcp.katto.tech/mcp` (Streamable HTTP)
- Auth: OAuth 2.1 (🔐)
- Added under **🎥 Multimedia**, alphabetical (after invideo).
- Evaluated on Glama (quality score available).