### PR TITLE
Add SocialRobot MCP server (social media scheduling) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
   🔓 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
+- [SocialRobot](https://socialrobot.io/mcp) `https://socialrobot.io/api/mcp`
+  🔓 - Connect anonymously to browse the tool list, sign in with OAuth to schedule and analyze posts on 9 platforms including Instagram, LinkedIn, X, and TikTok.
 - [Superpowers.social](https://superpowers.social) `https://superpowers.social/mcp`
   [![Superpowers.social MCP connector](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers/badges/score.svg)](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers)
   🔓 - Read-only search and retrieval of live X/Twitter and Reddit posts, threads, users, and subreddits.

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
   🔓 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
 - [SocialRobot](https://socialrobot.io/mcp) `https://socialrobot.io/api/mcp`
+  [![SocialRobot MCP connector](https://glama.ai/mcp/connectors/io.socialrobot/socialrobot-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.socialrobot/socialrobot-mcp)
   🔓 - Connect anonymously to browse the tool list, sign in with OAuth to schedule and analyze posts on 9 platforms including Instagram, LinkedIn, X, and TikTok.
 - [Superpowers.social](https://superpowers.social) `https://superpowers.social/mcp`
   [![Superpowers.social MCP connector](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers/badges/score.svg)](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers)


### PR DESCRIPTION
Adds the [SocialRobot](https://socialrobot.io/mcp) MCP server to the Social Media section.

- **Server:** `https://socialrobot.io/api/mcp` (remote, Streamable HTTP; answers MCP `initialize`)
- **Auth:** OAuth 2.0 + PKCE (browser authorize flow), API keys also accepted
- **Tools:** 20 (publishing, media upload, analytics, audience insights, best-time windows), all OAuth-scoped, none anonymously callable
- **Platforms:** Instagram, LinkedIn, X, TikTok, Facebook, Threads, Pinterest, Bluesky, Mastodon
- **Pricing:** included on every plan, including the free tier
- **Docs:** https://socialrobot.io/mcp
