### PR TITLE
Add Social Fetch remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![OmniSocials MCP connector](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials/badges/score.svg)](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials)
   🔑 - Publish and schedule posts across social networks.
 
+- [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
+  🔐 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
+
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 
 - [Intercom](https://intercom.com) `https://mcp.intercom.com/mcp`

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Publish and schedule posts across social networks.
 
 - [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
-  🔐 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
+  🔓 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
 
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 


### PR DESCRIPTION
Adds [Social Fetch](https://www.socialfetch.dev) to the Social Media section.

Hosted remote MCP: `https://api.socialfetch.dev/mcp`

Public social media scraping API (profiles, posts, comments, transcripts), live on every request.