### PR TITLE
Add nohumans.directory (Aggregators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
 - [nohumans.directory](https://nohumans.directory) `https://api.nohumans.directory/mcp`
+  [![nohumans.directory MCP connector](https://glama.ai/mcp/connectors/directory.nohumans/registry/badges/score.svg)](https://glama.ai/mcp/connectors/directory.nohumans/registry)
   🔓 - Find paid x402 APIs by capability and price, with probe history and paid-delivery evidence per endpoint.
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
   [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
+- [nohumans.directory](https://nohumans.directory) `https://api.nohumans.directory/mcp`
+  🔓 - Find paid x402 APIs by capability and price, with probe history and paid-delivery evidence per endpoint.
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
   [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)
   🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.


### PR DESCRIPTION
**Server:** nohumans.directory
**Endpoint:** `https://api.nohumans.directory/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

A remote MCP server over a registry of paid (x402) APIs: ~5,000 endpoints on ~1,900 hosts, re-probed every 25 minutes, plus a paid-delivery census — we pay endpoints real USDC and record whether what came back was actually delivered, with settlement proven on chain.

Tools: `find_paid_service` (semantic search with price, chain and reputation filters), `get_service_details` (full record: probe history, observed 402 terms, paid-verification outcome, on-chain payment activity), `resolve_endpoint` (verdict on a URL you already hold).

Streamable HTTP, no authentication, no signup. Docs: https://nohumans.directory/integrate · method and corrections: https://nohumans.directory/methodology

Placed in Aggregators next to TaskFuel, since it fronts many paid services rather than selling one. Repo starred.