### PR TITLE
Add EveryInfra to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔗 <a name="aggregators"></a>Aggregators
 
+- [EveryInfra](https://everyinfra.com) `https://api.everyinfra.com/mcp`
+  🔑 - Query structured public data, search the web, solve CAPTCHAs, and clean eligible EveryData results.
 - [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.


### PR DESCRIPTION
**Server:** EveryInfra  
**Endpoint:** https://api.everyinfra.com/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in Aggregators and ordered alphabetically
- [x] Business tool calls use a Bearer API key

Authentication note: EveryInfra intentionally leaves `initialize` and `tools/list` open so clients and directories can discover the server. Business `tools/call` requests require `Authorization: Bearer <API_KEY>`, so the entry uses the `🔑` marker. A no-credential CI probe can therefore observe an initialize result even though business calls are authenticated.