### PR TITLE
Add AI Applyd to Workplace & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🏢 <a name="workplace--productivity"></a>Workplace & Productivity
 
+- [AI Applyd](https://aiapplyd.com/mcps) `https://mcp.aiapplyd.com/mcp`
+  [![AI Applyd MCP connector](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd)
+  🔐 - Score a resume the way the screening software scores it, rewrite it for a role, write the cover letter, prepare for the interview, and submit the application on the employer's own hiring system across 12 ATS platforms.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [AI Applyd](https://aiapplyd.com/mcps) `https://mcp.aiapplyd.com/mcp`
   [![AI Applyd MCP connector](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd)
-  🔐 - Score a resume the way the screening software scores it, rewrite it for a role, write the cover letter, prepare for the interview, and submit the application on the employer's own hiring system across 12 ATS platforms.
+  🔓 - ATS resume scoring, per-role resume rewriting, cover letters, interview prep, job matching, and auto-apply that submits on the employer's own hiring system across 12 ATS platforms. Sign in with Google to run a tool.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.


### PR DESCRIPTION
Moved here from [awesome-mcp-servers#11076](https://github.com/punkpeye/awesome-mcp-servers/pull/11076) at your request, since this is a hosted server. Three lines added, nothing else touched.

A remote MCP server for job applications. It scores a resume the way screening software scores it, rewrites it for a specific role, writes the cover letter, prepares interview answers, and submits the application on the employer's own hiring system across 12 ATS platforms: Workday, Greenhouse, Lever, Ashby, Workable, iCIMS, Personio, Recruitee, Teamtailor, Rippling, Breezy and SmartRecruiters.

| | |
|---|---|
| Endpoint | `https://mcp.aiapplyd.com/mcp` (Streamable HTTP) |
| Auth | 🔐 OAuth 2.1, PKCE S256, dynamic client registration (RFC 7591) |
| Surface | 10 tools, 3 prompts, 3 resources |
| Glama connector | [rated **A**](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd) |
| MCP Registry | `io.github.whateverneveranywhere/aiapplyd` |
| Source | https://github.com/aiapplyd/aiapplyd-mcp (MIT) |

Introspection is open, so the entry is verifiable without signing in:

```bash
SID=$(curl -s -D- -o /dev/null -X POST https://mcp.aiapplyd.com/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' \
  | grep -i '^mcp-session-id' | tr -d '\r' | awk '{print $2}')

curl -s -X POST https://mcp.aiapplyd.com/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H "Mcp-Session-Id: $SID" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
```

Every tool declares `readOnlyHint` and `destructiveHint`. Two are destructive and marked so: replacing saved job preferences, and submitting a real application to a real employer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ79ztFrKUv58udAi3ZJ2X