### PR TITLE
Add ResuMakeAi 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [NoClick](https://www.noclick.com/mcp) `https://api.noclick.io/mcp`
   [![NoClick MCP connector](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick)
   🔐 - Build, run, and monitor workflows and background AI agents across connected apps.
+- [ResuMakeAi](https://www.resumakeai.com) `https://www.resumakeai.com/api/mcp`
+  [![ResuMakeAi MCP connector](https://glama.ai/mcp/connectors/com.resumakeai/resu-make-ai/badges/score.svg)](https://glama.ai/mcp/connectors/com.resumakeai/resu-make-ai)
+  🔓 - Score a resume against a job description for ATS parsing, match percentage, and missing keywords.
 
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 


### PR DESCRIPTION
Adds ResuMakeAi under Workplace & Productivity — a free, unauthenticated MCP server that scores a resume against a job description (ATS parsing score, match percentage, missing keywords). Streamable HTTP transport, no auth.

- Homepage: https://www.resumakeai.com
- Endpoint: https://www.resumakeai.com/api/mcp
- Glama connector (badge source): https://glama.ai/mcp/connectors/com.resumakeai/resu-make-ai

Endpoint answers `initialize` correctly, verified locally before opening this. Alphabetically placed after NoClick in Workplace & Productivity.