### PR TITLE
Add Vilix AI to Knowledge & Memory 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
+- [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
+  [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
+  🔐 - Save and retrieve shared conversation history, projects, tasks, and preferences across AI tools and devices.
 
 ### 🎯 <a name="marketing"></a>Marketing
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
 - [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
-  🔐 - Save and retrieve shared conversation history, projects, tasks, and preferences across AI tools and devices.
+  🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
Adds Vilix AI to Knowledge & Memory as a persistent shared AI memory layer across tools and devices. Memory continues across chats and sessions, with full conversation history and unlimited memory on paid plans. Its hosted MCP tools retrieve saved conversations, projects, tasks, and preferences from the same shared memory.

Resubmits punkpeye/awesome-mcp-servers#13718 here as requested in [the maintainer's migration notice](https://github.com/punkpeye/awesome-mcp-servers/pull/13718#issuecomment-5587045467).

**Server:** [Vilix AI](https://vilix.ai)
**Endpoint:** `https://api.vilix.ai/mcp`
**Transport and auth:** Streamable HTTP with OAuth. Public sign-up is available.
**Glama connector:** https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai

- [x] The endpoint is public and answers an MCP `initialize` request with the expected OAuth challenge.
- [x] Entry is in the correct category, in alphabetical order.
- [x] Auth marker matches what the endpoint actually does.

Validation: an unauthenticated `initialize` POST returns HTTP 401 with `WWW-Authenticate: Bearer resource_metadata="https://api.vilix.ai/.well-known/oauth-protected-resource/mcp"`, matching the repository's OAuth probe. The Glama connector page and score badge both return HTTP 200. The description stays within the 120-character limit, and `git diff --check` passes. The [pricing page](https://vilix.ai/pricing) confirms unlimited memory and full history on paid plans; Free has a starter quota, and paid usage is subject to fair use.
