### PR TITLE
Add FARPY remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vercel](https://vercel.com) `https://mcp.vercel.com`
   [![Vercel MCP connector](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp)
   🔐 - Manage Vercel projects, deployments, and logs.
-
+- [FARPY](https://farpy.com) ☁️ `https://api.farpy.com/mcp`
+  🔑 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
+  
 ### 💬 <a name="communication"></a>Communication
 
 - [Resend](https://resend.com) `https://mcp.resend.com/mcp`

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Cloudflare Bindings](https://developers.cloudflare.com/agents/model-context-protocol/) `https://bindings.mcp.cloudflare.com/mcp`
   🔐 - Build on Workers KV, R2, D1, and other Cloudflare bindings.
-- [FARPY](https://farpy.com) ☁️ `https://api.farpy.com/mcp`
+- [FARPY](https://farpy.com) `https://api.farpy.com/mcp`
+  [![FARPY MCP connector](https://glama.ai/mcp/connectors/com.farpy.api/farpy/badges/score.svg)](https://glama.ai/mcp/connectors/com.farpy.api/farpy)
   🔐 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
 - [Floot](https://floot.com) `https://mcp.floot.com/mcp`
   [![Floot MCP connector](https://glama.ai/mcp/connectors/com.floot/floot/badges/score.svg)](https://glama.ai/mcp/connectors/com.floot/floot)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Vercel MCP connector](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp)
   🔐 - Manage Vercel projects, deployments, and logs.
 - [FARPY](https://farpy.com) ☁️ `https://api.farpy.com/mcp`
-  🔑 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
+  🔐 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
   
 ### 💬 <a name="communication"></a>Communication
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Cloudflare Bindings](https://developers.cloudflare.com/agents/model-context-protocol/) `https://bindings.mcp.cloudflare.com/mcp`
   🔐 - Build on Workers KV, R2, D1, and other Cloudflare bindings.
+- [FARPY](https://farpy.com) ☁️ `https://api.farpy.com/mcp`
+  🔐 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
 - [Floot](https://floot.com) `https://mcp.floot.com/mcp`
   [![Floot MCP connector](https://glama.ai/mcp/connectors/com.floot/floot/badges/score.svg)](https://glama.ai/mcp/connectors/com.floot/floot)
   🔐 - Write React pages and serverless endpoints, provision Postgres and auth, run SQL, read logs, and publish to a live URL.
@@ -150,8 +152,6 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vercel](https://vercel.com) `https://mcp.vercel.com`
   [![Vercel MCP connector](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp)
   🔐 - Manage Vercel projects, deployments, and logs.
-- [FARPY](https://farpy.com) ☁️ `https://api.farpy.com/mcp`
-  🔐 - Run verified Blender GPU workloads, track jobs, retrieve artifacts, and inspect execution receipts.
   
 ### 💬 <a name="communication"></a>Communication
 


### PR DESCRIPTION
Adds FARPY as a hosted remote MCP server.

FARPY exposes verified Blender GPU execution through MCP, including workload submission, job status, artifact retrieval, and execution receipts.

**Server:** FARPY  
**Endpoint:** https://api.farpy.com/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does