### PR TITLE
Add Vibe Prospecting remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Company logos, brand colors, and firmographic data by domain.
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
+- [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
+  🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
**Server:** [Vibe Prospecting](https://vibeprospecting.ai), built and operated by Explorium.
**Endpoint:** `https://vibeprospecting.explorium.ai/mcp`

- [x] The endpoint is public and responds to an MCP `initialize` request with the expected OAuth authentication challenge.
- [x] Entry is in the correct category (Marketing), in alphabetical order.
- [x] Auth marker matches what the endpoint actually does.

Vibe Prospecting provides hosted B2B company/contact discovery, lead-list enrichment, and business-signal research. Users connect over Streamable HTTP and sign in with their Vibe Prospecting account through OAuth.

This resubmits https://github.com/punkpeye/awesome-mcp-servers/pull/13985 to the remote-server list as requested by @punkpeye when closing that PR.

Validation: sent the same credential-free `initialize` payload and protocol version used by this repository's CI. The endpoint returned HTTP 401 with `WWW-Authenticate: Bearer`, which the workflow accepts as an OAuth-protected endpoint. The two-line entry follows the required format, its description is under 120 characters, and the endpoint is not already listed. No optional Glama connector badge is claimed.

- Source repository: https://github.com/explorium-ai/vibeprospecting-mcp
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.explorium-ai/vibeprospecting
