### PR TITLE
Add Fatstack to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 * 🧰 - [Other Tools & Integrations](#other-tools--integrations)
 
 ### 🔗 <a name="aggregators"></a>Aggregators
-
+- [Fatstack](https://www.fatstack.net) `https://echo.fatstack.net/mcp`
+  🔓 - Marketplace of MCP servers and APIs that agents pay for per call in USDC over x402 on Base; connect anonymously and pay only when you call a tool.
 - [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.


### PR DESCRIPTION
Fatstack is a marketplace of MCP servers and APIs that agents discover and pay for per call, in USDC over x402 on Base. Connection is anonymous — initialize and tools/list need no key and no payment; only tools/call settles a payment.

Endpoint: https://echo.fatstack.net/mcp (Streamable HTTP). 
Source for the SDK and contracts: https://github.com/f4tst4ck/fatstack-tools

Disclosure: I run Fatstack.