### PR TITLE
Add Countersignatory to Agreements & Coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🤝 <a name="agreements--coordination"></a>Agreements & Coordination
 
+- [Countersignatory](https://countersignatory.com) `https://countersignatory.com/mcp`
+  [![Countersignatory MCP connector](https://glama.ai/mcp/connectors/com.countersignatory/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.countersignatory/mcp)
+  🔓 - Live spot prices for verified human judgment, sign-off and notarisation: quote what a verified human would cost for a task, register interest at that price, and read the public Spot Index.
 - [Elicitly](https://www.elicitly.ai) `https://mcp.elicitly.ai/mcp`
   [![Elicitly MCP connector](https://glama.ai/mcp/connectors/ai.elicitly/pro/badges/score.svg)](https://glama.ai/mcp/connectors/ai.elicitly/pro)
   🔐 - Human-in-the-loop for AI agents: confirmations, forms, and durable approvals that reach any device, with an audit trail.


### PR DESCRIPTION
**Server:** Countersignatory
**Endpoint:** https://countersignatory.com/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Moved here from awesome-mcp-servers #13937 per the split. Claimed Glama connector (DNS-verified) and published in the official MCP Registry as `com.countersignatory/mcp`.
