### PR TITLE
Add Made Good Designs — typography & brand-design inspiration 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Figma](https://figma.com) `https://mcp.figma.com/mcp`
   [![Figma MCP connector](https://glama.ai/mcp/connectors/com.figma.mcp/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.figma.mcp/mcp)
   🔐 - Read Figma files and turn frames and components into code.
+- [Made Good Designs](https://madegooddesigns.com/inspiration/) `https://madegooddesigns.com/inspiration/mcp`
+  🔓 - Search a curated gallery of typography and brand-design inspiration with colour palettes, tags, and source links.
 
 ### 🌐 <a name="browser-automation"></a>Browser Automation
 


### PR DESCRIPTION
Adds **Made Good Designs** to 🎨 Art & Design.

- **Endpoint:** `https://madegooddesigns.com/inspiration/mcp` — hosted Cloudflare Worker, Streamable HTTP (JSON-RPC 2.0), protocol `2025-06-18`.
- **Auth:** 🔓 none — public, read-only, usable by anyone.
- **Handshake:** answers MCP `initialize` and `tools/list` (4 tools: search_design_inspiration, list_inspiration_themes, browse_inspiration_by_theme, search_annual_reports).
- **What it does:** searches a curated gallery of typography & brand-design inspiration (colour palettes, tags, source links) plus an annual-reports archive, with links back to madegooddesigns.com.

Previously submitted to awesome-mcp-servers (#12267); moving here per the maintainer's note that remote/hosted servers belong in this list. Repo starred. No Glama connector badge included (the server's current Glama listing is a `/mcp/servers/` entry, not a `/mcp/connectors/` one) to avoid a failing badge check.