### PR TITLE
Add Stienhardt hosted diamond MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
+- [Stienhardt Diamond MCP](https://stienhardt.com/agents.md?utm_source=awesome_remote_mcp&utm_medium=directory&utm_campaign=diamond_mcp) `https://diamond-mcp.stienhardt.workers.dev/mcp`
+  🔓 - Diamond education, grading-report guidance, face-up size estimates, and read-only jewelry catalog search.
 
 ### 🌳 <a name="environment"></a>Environment
 


### PR DESCRIPTION
Adds Stienhardt's public hosted diamond tools to E-Commerce. This follows the maintainer's request in punkpeye/awesome-mcp-servers#13384 to move hosted servers to this list. I maintain this endpoint for Stienhardt.

**Server:** Stienhardt Diamond MCP
**Endpoint:** https://diamond-mcp.stienhardt.workers.dev/mcp

- [x] The endpoint is public and answers an MCP `initialize` request.
- [x] Entry is in the correct category, in alphabetical order.
- [x] Auth marker matches what the endpoint actually does.

Verified September 8, 2026: unauthenticated initialize returned HTTP 200 and `tools/list` returned ten tools. Eight cover sourced diamond education, grading-report guidance, and size estimates. Two provide read-only public catalog search and product details. Loose-diamond catalog listings do not verify stock. This endpoint does not create carts, open checkouts, or take payment.

The provider documentation is the homepage link. No Glama connector badge is included because the hosted connector has not been accepted; the existing Glama local-server badge would describe a different entry.
