### PR TITLE
Gemalli: note that no account is required 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Analyze FTIR spectra, search spectral libraries, and retrieve peak and literature evidence.
 - [Gemalli](https://gemalli.com/en/developers) `https://gemalli.com/api/mcp`
   [![Gemalli MCP connector](https://glama.ai/mcp/connectors/com.gemalli/trade/badges/score.svg)](https://glama.ai/mcp/connectors/com.gemalli/trade)
-  🔓 - Search verified manufacturers, screen counterparties against UN/OFAC/EU sanctions lists, and look up HS codes and dual-use export controls for cross-border trade.
+  🔓 - Search verified manufacturers, screen counterparties against UN/OFAC/EU sanctions lists, and look up HS codes and dual-use export controls for cross-border trade — no account required.
 - [gluten-free.fr](https://gluten-free.fr) `https://gluten-free.fr/api/mcp`
   🔓 - Verified gluten-free product catalogue and comparison data for the French market.
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`


### PR DESCRIPTION
Small follow-up to #38 — one line, description only.

The original entry carried `🆓` alongside `🔓`, but the format check reads it as an unrecognized marker (`check-submission.yml` whitelists only the three auth markers), so it was dropped on merge. Rather than ask for a workflow change, this just says it in the sentence:

> ... dual-use export controls for cross-border trade — **no account required**.

Same information, no marker involved. Endpoint and auth are unchanged: `🔓`, anonymous, no key.
