### PR TITLE
Add Photo AI Studio 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Read Figma files and turn frames and components into code.
 - [Made Good Designs](https://madegooddesigns.com/inspiration/) `https://madegooddesigns.com/inspiration/mcp`
   🔓 - Search a curated gallery of typography and brand-design inspiration with colour palettes, tags, and source links.
+- [Photo AI Studio](https://www.photoaistudio.com/mcp) `https://www.photoaistudio.com/api/mcp`
+  🔓 - Generate AI photos from a selfie across 150+ themes, edit images, and create video; OAuth for account tools.
 
 ### 🌐 <a name="browser-automation"></a>Browser Automation
 


### PR DESCRIPTION
Adds Photo AI Studio to **Art & Design**, placed alphabetically after Figma.

```
- [Photo AI Studio](https://www.photoaistudio.com/mcp) `https://www.photoaistudio.com/api/mcp`
  🔐 - Generate AI photos from a selfie across 150+ themes, edit images, and create video.
```

Against the criteria in CONTRIBUTING.md:

- **Reachable at a public URL.** `https://www.photoaistudio.com/api/mcp` answers `initialize` with `protocolVersion: 2025-06-18` and `serverInfo: {"name":"photoaistudio","version":"2.0.0"}`.
- **Usable by anyone.** Public sign-up, and the endpoint is the same URL for every user.
- **Streamable HTTP.** Stateless, one JSON response per request; no local process.
- **Not behind a paywall.** Anonymous callers complete the handshake and can call four discovery tools (`list_photo_themes`, `get_pricing`, `get_service_overview`, `get_api_capabilities`) with no account. The eight account tools return 401 with `WWW-Authenticate` naming the protected resource metadata, which is what starts the OAuth flow.
- **🔐 marker.** OAuth 2.1 with PKCE and dynamic client registration, discoverable at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`.

Already published in the official MCP registry as `com.photoaistudio/photo-ai-studio`.

No Glama connector badge yet; happy to add one in a follow-up once the connector is listed there.