### PR TITLE
Add Rechnungslotse — German e-invoicing (XRechnung/ZUGFeRD) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Query Plaid dashboard data for connected financial accounts.
 - [Quidli Connect](https://connect.quid.li) `https://mcp.connect.quid.li`
   🔓 - Resolve social handles to EVM and Solana wallet addresses, score onchain reputation, and send USDC to identities.
+- [Rechnungslotse](https://rechnungslotse.de/mcp) `https://rechnungslotse.de/api/mcp`
+  [![Rechnungslotse MCP connector](https://glama.ai/mcp/connectors/de.rechnungslotse/e-rechnung/badges/score.svg)](https://glama.ai/mcp/connectors/de.rechnungslotse/e-rechnung)
+  🔓 - German e-invoicing: create, validate and read XRechnung and ZUGFeRD against EN 16931, every violation with its rule ID.
 - [Sector Pulse](https://sector-pulse.app) `https://sector-pulse.app/api/mcp`
   [![Sector Pulse MCP connector](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.christianhonap7-sys/sector-pulse)
   🔓 - Live US sector rotation: 30 sector baskets ranked every session, versioned rosters, daily record; history needs a key.


### PR DESCRIPTION
**Server:** Rechnungslotse
**Endpoint:** `https://rechnungslotse.de/api/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

A hosted server for **German electronic invoicing**. Germany's e-invoicing mandate is staged: businesses must be able to receive e-invoices since January 2025, and must issue them from 2027/2028 depending on turnover. This server covers both sides.

Eighteen tools. Seven need no account and no key — validate an XRechnung or ZUGFeRD file against EN 16931 and the full KoSIT rule set, read an invoice into structured data, explain a rejection rule ID in plain language, check the mandatory fields of § 14 UStG, verify a Leitweg-ID check digit, answer when a given business falls under the mandate, and check the small-business thresholds of § 19 UStG. Uploaded files are held in memory for the call and never stored.

The remaining eleven act inside a connected business over OAuth 2.1: create validated invoices, log and bill work, record payments, list overdue items, and produce VAT totals with ELSTER field numbers.

`tools/list` and `initialize` both work unauthenticated, so a client sees every tool before connecting — hence the 🔓 marker. Calling one of the account tools without a token returns 401 with a `WWW-Authenticate` header pointing at the resource metadata; PKCE, dynamic client registration and client ID metadata documents are all supported.

Also listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as `de.rechnungslotse/e-rechnung`. Repository with full documentation: https://github.com/XKalleX/rechnungslotse-mcp

No Glama connector badge yet — I will add one in a follow-up once the connector is listed.

This was submitted as [awesome-mcp-servers#13845](https://github.com/punkpeye/awesome-mcp-servers/pull/13845) before the split; reopening here as directed.
