### PR TITLE
Add GridHub electricity market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ambee](https://ambeedata.com) `https://api-mcp-server.ambeedata.com/mcp`
   [![Ambee MCP connector](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee/badges/score.svg)](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee)
   🔓 - Weather, air quality, pollen, and other environmental data.
+- [GridHub](https://grid-hub.app/developers) `https://api.grid-hub.app/mcp`
+  [![GridHub MCP connector](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub)
+  🔓 - Live and historical electricity prices and demand for 25 grid zones (US, EU, GB, AU); free sample mode, key, or x402.
 
 ### 📂 <a name="file-storage"></a>File Storage
 


### PR DESCRIPTION
**Server:** GridHub
**Endpoint:** `https://api.grid-hub.app/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Hosted Streamable HTTP, stateless, no install. Six read-only tools for wholesale electricity prices and demand across 25 grid zones (7 US ISOs, 12 European bidding zones, Great Britain, 5 Australian NEM regions), sourced from EIA, ENTSO-E, NESO, Elexon and AEMO into one schema. Connects anonymously — with no credentials the tools return real current data in sample mode. A free API key (500/day) or x402 pay-per-call unlocks full responses.