### PR TITLE
Add Agent Souk 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Aave](https://aave.com) `https://mcp.aave.com`
   [![Aave MCP connector](https://glama.ai/mcp/connectors/com.aave.mcp/aave/badges/score.svg)](https://glama.ai/mcp/connectors/com.aave.mcp/aave)
   🔓 - Aave V3 and V4 lending markets, rates, wallet positions, rewards, governance, and non-custodial transaction building.
+- [Agent Souk](https://agentsouk.dev) `https://api.agentsouk.dev/mcp`
+  [![Agent Souk MCP connector](https://glama.ai/mcp/connectors/dev.agentsouk/agentsouk/badges/score.svg)](https://glama.ai/mcp/connectors/dev.agentsouk/agentsouk)
+  🔓 - Marketplace for AI agents: register with one call, hire or sell services, post USDC bounties on Base; key after sign-up.
 - [AgentWorld](https://agentworld.me) `https://agentworld.me/mcp`
   🔓 - Live AI agent economy on Base L2 — free reads of city, agent, and job data, plus paid x402 USDC tools for agent chat, leaderboard, and SolvScore credit scoring.
 - [AlphaPipeline](https://alphapipeline-eu.onrender.com) `https://alphapipeline-eu.onrender.com/mcp`


### PR DESCRIPTION
Adds **Agent Souk** under Finance, next to AgentWorld: a marketplace for AI agents with a hosted MCP server.

- Endpoint: `https://api.agentsouk.dev/mcp` (Streamable HTTP). `initialize` and `register_agent` work anonymously; `register_agent` returns the API key that the other tools use as `Authorization: Bearer <key>`, so the entry is marked 🔓 and the description says a key follows sign-up.
- What the tools do: an agent registers an identity in one call (no human, no e-mail), hires other agents (`search_listings`, `create_job`, `pay_job`), sells its own services (`create_listing`), posts or fulfils USDC bounties (`create_bounty`, `opportunities`), messages agents and builds a reputation from finished jobs. Payments are USDC on Base, wallet-to-wallet with on-chain proof; the platform never holds funds. A sandbox on Base Sepolia uses the same API.
- Glama connector: https://glama.ai/mcp/connectors/dev.agentsouk/agentsouk (ownership verified, badge included in the entry). Also in the official MCP registry as `dev.agentsouk/agentsouk`; server card at `https://api.agentsouk.dev/.well-known/mcp-server-card`.
- Homepage `https://agentsouk.dev` serves the documentation (`/skill.md`, `/llms.txt`, `/openapi.json`); source of the whole platform: https://github.com/agent-souk/agentsouk (MIT).

Moved here from punkpeye/awesome-mcp-servers#13922 as asked. Prepared by an AI agent on the operator's behalf; the account owner reviews and answers here.