### PR TITLE
Add makesPDF - compliant PDF rendering from Markdown or a DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ionic Framework MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/ionic-framework/) `https://ionic-framework-mcp.capawesome.io/mcp`
   [![Ionic Framework MCP connector](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp)
   🔓 - Unofficial: search the Ionic Framework docs for v8 and v9, with the component API and usage examples.
+- [makesPDF](https://makespdf.com/docs/mcp) `https://makespdf.com/api/v1/mcp`
+  [![makesPDF MCP connector](https://glama.ai/mcp/connectors/com.makespdf/makespdf/badges/score.svg)](https://glama.ai/mcp/connectors/com.makespdf/makespdf)
+  🔑 - Convert Markdown or a compact DSL into tagged, accessible PDFs: PDF/A-2A and PDF/UA-1 dual-compliant.
 - [mumo](https://mumo.chat) `https://mumo.chat/api/mcp`
   [![mumo MCP connector](https://glama.ai/mcp/connectors/chat.mumo/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/chat.mumo/mcp)
   🔓 - A frontier panel for your agent: Ask Claude, GPT, Grok, and more. Get their independent responses *and* reactions to each other. See what they agree with, challenge, or want to explore further — in their own words. For architecture, plan/spec review, and strategy.


### PR DESCRIPTION
Adds [makesPDF](https://makespdf.com/docs/mcp) under Developer Tools, alphabetically between Globalping and OpenRouter.

Moved here from awesome-mcp-servers#12403, which you closed with the remote/local split. This list is a much better fit — that PR spent most of its life on the fact that makesPDF is a hosted service with no runnable repo, which is the premise of this list rather than a problem with the entry.

**Entry**

```markdown
- [makesPDF](https://makespdf.com/docs/mcp) `https://makespdf.com/api/v1/mcp`
  [![makesPDF MCP connector](https://glama.ai/mcp/connectors/com.makespdf/makespdf/badges/score.svg)](https://glama.ai/mcp/connectors/com.makespdf/makespdf)
  🔑 - Convert Markdown or a compact DSL into tagged, accessible PDFs: PDF/A-2A and PDF/UA-1 dual-compliant.
```

**Against the requirements**

- **Reachable at a public URL, answers `initialize`.** `https://makespdf.com/api/v1/mcp`, Streamable HTTP. Discovery is keyless — `initialize`, `ping`, `tools/list`, `resources/list` and `resources/read` all answer an unauthenticated POST, so your CI probe gets a real handshake rather than a 401. `tools/call` requires a key.
- **Usable by anyone.** Public sign-up; API key auth (hence 🔑). Wallet-holding agents can also pay per call over x402 without an account.
- **Streamable HTTP.** No local process.
- **Glama connector badge.** Listed at [com.makespdf/makespdf](https://glama.ai/mcp/connectors/com.makespdf/makespdf) via the official MCP Registry, inspected and scored **A, 4.4/5.0** (5/5 on all four categories).

**What the server does**

Ten tools covering the full authoring loop: validate Markdown or DSL for accessibility and catalog correctness, preview DSL with sample data (free, watermarked), save/list/fetch/update/delete templates, browse a curated template library, and render to PDF. Rendering is deterministic — no AI call, no headless browser — and every PDF is PDF/A-2A archival plus PDF/UA-1 accessibility compliant, validated against veraPDF on each release.

Verification for the description line: 101 characters, ends in a period.