### PR TITLE
Add Mysocial — creator social media history MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AdminHub for Telegram](https://adminhub.tools/mcp/) `https://backend-git-production-cb93.up.railway.app/mcp`
   [![AdminHub for Telegram MCP connector](https://glama.ai/mcp/connectors/tools.adminhub/telegram/badges/score.svg)](https://glama.ai/mcp/connectors/tools.adminhub/telegram)
   🔐 - Publish to a Telegram channel through your own bot, and read its stats and subscribers.
+- [Mysocial](https://mysocial.io/mcp/) `https://app.mysocial.io/mcp`
+  🔐 - Read a creator's own Instagram, TikTok, YouTube, LinkedIn and Threads history: posts, metrics, transcripts, comments and audience.
 - [OmniSocials](https://omnisocials.com) `https://mcp.omnisocials.com/`
   [![OmniSocials MCP connector](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials/badges/score.svg)](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials)
   🔑 - Publish and schedule posts across social networks.


### PR DESCRIPTION
Adds **Mysocial** under Social Media.

- Endpoint: `https://app.mysocial.io/mcp` (Streamable HTTP, OAuth 2.1 with PKCE and dynamic client registration; the unauthenticated handshake answers 401 with `WWW-Authenticate: Bearer resource_metadata=...`, RFC 9728 metadata at `/.well-known/oauth-protected-resource`).
- Public sign-up at https://app.mysocial.io; docs at https://mysocial.io/mcp/.
- What it does: reads a creator's *own* published history across Instagram, TikTok, YouTube, LinkedIn and Threads (posts, metrics, transcripts, comments, audience) so an assistant can work from what they already published. It does not post on the creator's behalf.

Moved here from punkpeye/awesome-mcp-servers#13425 as requested. No Glama badge yet; will add once the connector is listed.