### PR TITLE
Add ToolsMonk catalog MCP server to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
   [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)
   🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.
+- [ToolsMonk](https://toolsmonk.com) `https://toolsmonk.com/api/mcp`
+  [![ToolsMonk MCP connector](https://glama.ai/mcp/connectors/com.toolsmonk/catalog/badges/score.svg)](https://glama.ai/mcp/connectors/com.toolsmonk/catalog)
+  🔓 - Find the right one of 255 free browser-based PDF, image, text and SEO tools by describing the task.
 - [Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
   [![Zapier MCP connector](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier/badges/score.svg)](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier)
   🔐 - Run your Zapier actions across thousands of connected apps as MCP tools.


### PR DESCRIPTION
Adds **ToolsMonk** to **Aggregators**: a remote MCP server fronting a catalog of 255 free browser-based tools (PDF, image, text, SEO, developer, calculators).

Arriving here from [punkpeye/awesome-mcp-servers#13977](https://github.com/punkpeye/awesome-mcp-servers/pull/13977), which I closed because the server has no public source repository and pointing the entry at an unrelated repo of mine would have misrepresented what was being listed. @punkpeye pointed me at this list, which is exactly the right shape for it. Thank you for that.

**Server:** ToolsMonk
**Endpoint:** `https://toolsmonk.com/api/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

### Verified before opening

`initialize` handshake against production:

```
HTTP 200 · mcp-protocol-version: 2025-06-18
serverInfo: { name: "toolsmonk", version: "1.0.0" }
capabilities: tools, resources
```

`tools/list` returns 5: `search_tools`, `get_tool`, `list_tools`, `list_categories`, `get_site_info`.

Glama connector badge resolves (`com.toolsmonk/catalog`, real SVG, HTTP 200). Placement is alphabetical: Hubris, TaskFuel, **ToolsMonk**, Zapier.

### Details

| | |
|---|---|
| Transport | Streamable HTTP, stateless (no `Mcp-Session-Id`) |
| Auth | none, 🔓 |
| Rate limit | 120 req/min per IP |
| Docs | https://toolsmonk.com/developers/mcp |
| MCP registry | `com.toolsmonk/catalog`, DNS-verified |

### One honest caveat

It is a **catalog**, so it returns the matching tool and its URL rather than executing the conversion, and the entry is worded to say so ("find the right one of...") rather than implying it processes files. The server also reports a `runsInBrowser` flag per tool so an agent can tell the user whether their file would leave their device. Happy to move it to another category if Aggregators is not where you would put it.

Disclosure: I maintain ToolsMonk. One entry appended in alphabetical position; three lines added, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
