### PR TITLE
Add Evlek — Northern Cyprus property MCP (new Real Estate category) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 * 🎥 - [Multimedia](#multimedia)
 * 💳 - [Payments](#payments)
 * 📋 - [Project Management](#project-management)
+* 🏠 - [Real Estate](#real-estate)
 * 🔎 - [Search & Data Extraction](#search--data-extraction)
 * 🔒 - [Security](#security)
 * 📣 - [Social Media](#social-media)
@@ -396,6 +397,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Manage Linear issues, projects, and cycles.
 - [monday.com](https://monday.com) `https://mcp.monday.com/mcp`
   🔐 - Manage monday.com boards, items, and updates.
+
+### 🏠 <a name="real-estate"></a>Real Estate
+
+- [Evlek](https://evlek.app/mcp) `https://evlek.app/api/mcp`
+  [![Evlek MCP connector](https://glama.ai/mcp/connectors/app.evlek/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/app.evlek/mcp-server)
+  🔓 - Search active Northern Cyprus sale and rental listings and compare asking prices by city and district.
 
 ### 🔎 <a name="search--data-extraction"></a>Search & Data Extraction
 


### PR DESCRIPTION
Adds a **Real Estate** category (nothing existing fit) with one entry.

```
- [Evlek](https://evlek.app/mcp) `https://evlek.app/api/mcp`
  [![Evlek MCP connector](https://glama.ai/mcp/connectors/app.evlek/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/app.evlek/mcp-server)
  🔓 - Search active Northern Cyprus sale and rental listings and compare asking prices by city and district.
```

**What it is.** Evlek is a property platform for Northern Cyprus (KKTC/TRNC). The endpoint is public, read-only and needs no authentication — 12 tools over Streamable HTTP covering listing search, listing detail, city and district comparison, an asking-price index, currency conversion and location lookup. Three of them also return interactive views (listing cards, listing detail with gallery, district price chart).

**Why it fits.** Hosted by us at `https://evlek.app/api/mcp`, open to anyone, no local process, answers `initialize`. It is also in the official MCP Registry as `app.evlek/mcp-server` (currently 2.1.0) and has a Glama connector, so the badge resolves.

Every aggregate it returns carries its sample size, and it deliberately ships no valuation, yield, forecast or legal-advice tool.

The index entry was added in the same alphabetical position as the section. Repo starred. This PR was prepared by an agent, hence the 🤖🤖🤖 opt-in from CONTRIBUTING.md.