### PR TITLE
Add Flash to Knowledge & Memory 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [docs2mcp](https://docs2mcp.com) `https://mcp.docs2mcp.com/mcp`
   [![docs2mcp MCP connector](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp)
   🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.
+- [Flash](https://flashmemorize.com) `https://flashmemorize.com/mcp`
+  🔐 - Spaced-repetition flashcards: create cards from notes, get quizzed by voice, and let FSRS schedule reviews.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.


### PR DESCRIPTION
Adds **Flash** under **Knowledge & Memory**, alphabetically between docs2mcp and Hugging Face.

- Endpoint: `https://flashmemorize.com/mcp` (Streamable HTTP)
- Auth: 🔐 OAuth 2.1 with PKCE and dynamic client registration; unauthenticated `initialize` returns 401 with a `WWW-Authenticate` header pointing at `/.well-known/oauth-protected-resource`.
- Public sign-up, free tier, no per-user endpoint URL.

Flash is spaced-repetition flashcards for studying with an AI assistant: the assistant creates cards from notes, quizzes the learner by voice, grades answers, and FSRS schedules every review. Source: https://github.com/flash-cards/flash (AGPL-3.0). No Glama connector badge yet.