### PR TITLE
Add APIzone to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 📊 <a name="monitoring"></a>Monitoring
 
+- [APIzone](https://apizone.io) `https://apizone.io/api/mcp`
+  🔓 - Check whether a third-party API is down, look up uptime history, or list recent outages across 294 independently-probed APIs (Stripe, OpenAI, AWS, GitHub, etc.).
 - [Cloudflare Observability](https://developers.cloudflare.com) `https://observability.mcp.cloudflare.com/mcp`
   🔐 - Query Workers logs, analytics, and error events.
 - [Grafana](https://grafana.com) `https://mcp.grafana.com/mcp`


### PR DESCRIPTION
Re-opening in the new remote-servers list per your note on #12856 (splitting local vs. remote).

- **Endpoint:** `https://apizone.io/api/mcp` (Streamable HTTP, verified `initialize` handshake works)
- **Auth:** 🔓 none — read-only, no key needed
- Independent uptime & status monitoring for 294 popular APIs (Stripe, OpenAI, AWS, GitHub, etc.) via own synthetic probes, not vendor status-page scraping.
- Tools: `list_apis`, `get_api_status`, `check_apis`, `get_api_uptime`, `list_recent_incidents`.

Placed alphabetically in Monitoring.