### PR TITLE
Add minia2a to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
+- [minia2a](https://minia2a.uk) `https://minia2a.uk/mcp`
+  🔓 - 1,600+ pay-per-call APIs — crypto data, web scraping, AI inference, token security — USDC on Base via x402.
 - [nohumans.directory](https://nohumans.directory) `https://api.nohumans.directory/mcp`
   [![nohumans.directory MCP connector](https://glama.ai/mcp/connectors/directory.nohumans/registry/badges/score.svg)](https://glama.ai/mcp/connectors/directory.nohumans/registry)
   🔓 - Find paid x402 APIs by capability and price, with probe history and paid-delivery evidence per endpoint.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
 - [minia2a](https://minia2a.uk) `https://minia2a.uk/mcp`
+  [![minia2a MCP connector](https://glama.ai/mcp/connectors/uk.minia2a/minia2a-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/uk.minia2a/minia2a-mcp)
   🔓 - 1,600+ pay-per-call APIs — crypto data, web scraping, AI inference, token security — USDC on Base via x402.
 - [nohumans.directory](https://nohumans.directory) `https://api.nohumans.directory/mcp`
   [![nohumans.directory MCP connector](https://glama.ai/mcp/connectors/directory.nohumans/registry/badges/score.svg)](https://glama.ai/mcp/connectors/directory.nohumans/registry)


### PR DESCRIPTION
Adds the **minia2a** remote MCP endpoint.

**Endpoint:** `https://minia2a.uk/mcp` (Streamable HTTP, protocolVersion 2025-06-18)

**What it does:** one endpoint exposing 1,600+ pay-per-call API services — crypto data, web scraping, AI inference, token security, DNS/WHOIS, gas monitoring, and DeFi data. Connect anonymously; each tool call settles in USDC on Base via x402 (no API keys, no subscription, no OAuth).

**Verified before opening:** `initialize` handshake returns `serverInfo.name=minia2a`, `version=5.0.0`, protocolVersion 2025-06-18. `tools/list` is call-gated per x402 semantics; `initialize` itself is open.

Placed in Aggregators (one MCP endpoint → many services), matching the TaskFuel precedent for paid per-request API marketplaces.