### PR TITLE
Add Stellary remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Manage Linear issues, projects, and cycles.
 - [monday.com](https://monday.com) `https://mcp.monday.com/mcp`
   🔐 - Manage monday.com boards, items, and updates.
+- [Stellary](https://stellary.co) `https://api.stellary.co/mcp`
+  🔐 - AI-native project boards, cockpit, and governed agent missions over hosted Streamable HTTP.
 
 ### 🏠 <a name="real-estate"></a>Real Estate
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [monday.com](https://monday.com) `https://mcp.monday.com/mcp`
   🔐 - Manage monday.com boards, items, and updates.
 - [Stellary](https://stellary.co) `https://api.stellary.co/mcp`
+  [![Stellary MCP connector](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management)
   🔐 - AI-native project boards, cockpit, and governed agent missions over hosted Streamable HTTP.
 
 ### 🏠 <a name="real-estate"></a>Real Estate


### PR DESCRIPTION
## Summary
Adds **Stellary** under Project Management: hosted Streamable HTTP MCP at `https://api.stellary.co/mcp` (OAuth 🔐).

Moved here from [punkpeye/awesome-mcp-servers#13197](https://github.com/punkpeye/awesome-mcp-servers/pull/13197) after the maintainer asked remote/hosted servers to use this list.

- Homepage: https://stellary.co
- Docs: https://stellary.co/docs/mcp/
- Official registry: `io.github.Anymfah/stellary-project-management`
- Auth: OAuth 2.1 (PAT Bearer also supported for clients without OAuth)

## Checklist
- [x] Starred the repository
- [x] Public endpoint (Streamable HTTP)
- [x] Alphabetical under Project Management
- [x] Auth marker 🔐