### PR TITLE
Add Sense2 to E-Commerce 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Run an Amazon seller brand from chat: profit analytics, PPC, inventory forecasting, listings, staged approvals.
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
+- [Sense2](https://sense2.com.au) `https://sense2.com.au/api/mcp`
+  🔓 - Search 4,000+ Australian promotional products, get quantity-break quotes, browse categories and case studies.
 - [Stienhardt Diamond MCP](https://stienhardt.com/agents.md?utm_source=awesome_remote_mcp&utm_medium=directory&utm_campaign=diamond_mcp) `https://diamond-mcp.stienhardt.workers.dev/mcp`
   🔓 - Diamond education, grading-report guidance, face-up size estimates, and read-only jewelry catalog search.
 


### PR DESCRIPTION
**Server:** Sense2 — Australian promotional products (custom branded merchandise) catalogue, Byron Bay, est. 1995
**Endpoint:** `https://sense2.com.au/api/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Auth marker matches what the endpoint actually does

Remote streamable-HTTP, JSON-RPC, read-only, no auth. 21 tools: catalogue search, quantity-break pricing quotes (`get_quote`), categories, curated collections, brand case studies, procurement facts. Discovery doc: `https://sense2.com.au/.well-known/mcp.json`. Also on the official MCP Registry as `io.github.24seagull-beep/sense2-catalogue`.

Moved here from punkpeye/awesome-mcp-servers#11543 at the maintainer's request (remote servers split into this list).

Verified live before opening:
```
initialize → HTTP 200, serverInfo: sense2-catalogue 1.0.0
tools/list → 21 tools
```
