### PR TITLE
Add Kyrodata to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - DeFi trading signals and market intelligence for agents on Base; x402 pay-per-call in USDC, no signup.
 - [Kyrodata](https://kyrodata.com) `https://mcp.kyrodata.com/mcp`
   [![Kyrodata MCP connector](https://glama.ai/mcp/connectors/com.kyrodata/kyrodata/badges/score.svg)](https://glama.ai/mcp/connectors/com.kyrodata/kyrodata)
-  🔑 - Brazilian exports and imports by HS code and partner, plus crop production, climate and commodity forecasts.
+  🔐 - Brazilian exports and imports by HS code and partner, plus crop production, climate and commodity forecasts.
 - [LitVM TCG Oracle](https://litvm.the-undesirables.com) `https://litvm.the-undesirables.com/mcp`
   [![LitVM TCG Oracle MCP connector](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle/badges/score.svg)](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle)
   🔓 - TCG price oracle for the LitecoinVM ecosystem: Merkle-proven prices, calibrated forecasts, fantasy souls; 13 free tools.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Historical return data for funds and tickers.
 - [Kristo Intelligence](https://kristo-intelligence-api.onrender.com) `https://kristo-intelligence-api.onrender.com/mcp`
   🔓 - DeFi trading signals and market intelligence for agents on Base; x402 pay-per-call in USDC, no signup.
+- [Kyrodata](https://kyrodata.com) `https://mcp.kyrodata.com/mcp`
+  [![Kyrodata MCP connector](https://glama.ai/mcp/connectors/com.kyrodata/kyrodata/badges/score.svg)](https://glama.ai/mcp/connectors/com.kyrodata/kyrodata)
+  🔑 - Brazilian exports and imports by HS code and partner, plus crop production, climate and commodity forecasts.
 - [LitVM TCG Oracle](https://litvm.the-undesirables.com) `https://litvm.the-undesirables.com/mcp`
   [![LitVM TCG Oracle MCP connector](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle/badges/score.svg)](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle)
   🔓 - TCG price oracle for the LitecoinVM ecosystem: Merkle-proven prices, calibrated forecasts, fantasy souls; 13 free tools.


### PR DESCRIPTION
Remote MCP server for **Brazilian foreign trade and commodity data**, moved here from `awesome-mcp-servers#13817` — that PR was closed when remote servers got their own list.

**What it serves:** exports and imports from MDIC/ComexStat since 2000, by HS code (SH4/SH6/NCM) and partner country, in USD FOB and kilograms — plus crop production, supply-and-demand balances, climate readings and commodity forecasts for hubs such as soybean, coffee, corn, beef and cocoa. 15 read-only tools.

Every comparison is like-for-like: two windows of equal length, each labelled with the period it actually measures. Every answer names its window and its source, and "no signal" is a real answer where the data does not support a verdict.

**Endpoint:** `https://mcp.kyrodata.com/mcp`, Streamable HTTP, stateless. Auth is a bearer key (`kd_live_…`) or OAuth 2.1 with PKCE and CIMD, so it answers `401` with `WWW-Authenticate` + `resource_metadata` rather than failing the handshake.

**Glama connector:** [`com.kyrodata/kyrodata`](https://glama.ai/mcp/connectors/com.kyrodata/kyrodata) — claimed by DNS TXT, `Healthy`, TDQS **A**. The badge in the entry resolves.

Also in the official MCP registry as `com.kyrodata/kyrodata`.

Repo starred, as CONTRIBUTING asks.