### PR TITLE
Add LiveDataLink 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
   [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
   🔓 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
+- [LiveDataLink](https://livedatalink.ai) `https://livedatalink.ai/mcp`
+  [![LiveDataLink MCP connector](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink)
+  🔓 - Query 294 tools across 60 public-data domains, spanning sanctions, courts, markets, health, energy, and government.
 - [Realask](https://realask.net) `https://realask.net/mcp`
   [![Realask MCP connector](https://glama.ai/mcp/connectors/io.github.danelas/realask/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.danelas/realask)
   🔓 - Verify facts about US local businesses by phone — stock, all-in price, availability — as typed answers with evidence.


### PR DESCRIPTION
**Server:** [LiveDataLink](https://livedatalink.ai)
**Endpoint:** `https://livedatalink.ai/mcp`

Adds LiveDataLink alphabetically under Search & Data Extraction. It exposes 294 tools across 60 public-data domains, including sanctions, courts, markets, health, energy, and government.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Validated September 8, 2026: anonymous `initialize` returned HTTP 200; anonymous `tools/list` returned all 294 tools with no pagination cursor. The Glama connector page and SVG badge both returned HTTP 200. Authentication is optional for anonymous evaluation, matching the directory's `🔓` classification.

The submitting account, `blackboxfoundry-ops`, has starred the repository. The description is 115 characters and `git diff --check` passes.