### PR TITLE
Add LibreJustice under a new Legal category

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 * 🍽️ - [Food & Dining](#food--dining)
 * 🎮 - [Gaming](#gaming)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
+* ⚖️ - [Legal](#legal)
 * 🎯 - [Marketing](#marketing)
 * 📊 - [Monitoring](#monitoring)
 * 🎥 - [Multimedia](#multimedia)
@@ -384,6 +385,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
   🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.
+
+### ⚖️ <a name="legal"></a>Legal
+
+- [LibreJustice](https://librejustice.fr) `https://librejustice.fr/mcp`
+  [![LibreJustice MCP connector](https://glama.ai/mcp/connectors/fr.librejustice/librejustice/badges/score.svg)](https://glama.ai/mcp/connectors/fr.librejustice/librejustice)
+  🔐 - French and European case law and legislation, searched in plain language and linked article by article.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
LibreJustice is a free search engine over French and European law: case law from both court orders, consolidated legislation as it stood on any date, and the citation graph that links them. ~3.8M decisions and ~3.7M articles, refreshed daily. Apache 2.0.

The endpoint is `https://librejustice.fr/mcp`, Streamable HTTP, OAuth 2.1 with dynamic client registration, open to any account. The connector is listed on Glama and scored: https://glama.ai/mcp/connectors/fr.librejustice/librejustice

Nothing fits it among the existing categories, so this adds a Legal one, between Knowledge & Memory and Marketing in the index and in the body. Happy to move the entry under Search & Data Extraction instead if you would rather not open a category for a single server.