### PR TITLE
Add TrustyCap to Cloud Platforms 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Create, deploy, and manage Netlify sites.
 - [Render](https://render.com) `https://mcp.render.com/mcp`
   🔐 - Deploy and inspect Render services, databases, and logs.
+- [TrustyCap](https://trustycap.com) `https://mcp.trustycap.com/mcp`
+  [![TrustyCap MCP connector](https://glama.ai/mcp/connectors/com.trustycap/trustycap/badges/score.svg)](https://glama.ai/mcp/connectors/com.trustycap/trustycap)
+  🔐 - Add production storage, data, jobs, webhooks, email and secrets to an app, then meter and bill the usage.
 - [Vercel](https://vercel.com) `https://mcp.vercel.com`
   [![Vercel MCP connector](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp)
   🔐 - Manage Vercel projects, deployments, and logs.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Deploy and inspect Render services, databases, and logs.
 - [TrustyCap](https://trustycap.com) `https://mcp.trustycap.com/mcp`
   [![TrustyCap MCP connector](https://glama.ai/mcp/connectors/com.trustycap/trustycap/badges/score.svg)](https://glama.ai/mcp/connectors/com.trustycap/trustycap)
-  🔐 - Add production storage, data, jobs, webhooks, email and secrets to an app, then meter and bill the usage.
+  🔓 - Start with no account: add production storage, data, jobs, webhooks, email and secrets to an app, then meter the usage.
 - [Vercel](https://vercel.com) `https://mcp.vercel.com`
   [![Vercel MCP connector](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.vercel/vercel-mcp)
   🔐 - Manage Vercel projects, deployments, and logs.


### PR DESCRIPTION
Moving this over from awesome-mcp-servers#13850, where you asked for remote servers to be listed here instead.

- **Endpoint:** `https://mcp.trustycap.com/mcp`, Streamable HTTP. `initialize` answers with a result and `serverInfo.name` trustycap.
- **Marker corrected to 🔓.** Thank you for the two nudges; the probe was right and the entry was out of date. Connecting takes no authentication: `initialize` answers 200 with no challenge, `tools/list` answers without a credential, and the tools a reader would actually evaluate the server with all run anonymously, including the one that provisions a free test workspace and returns a working test key.
- **What OAuth still guards.** The tools that act on a person's own connected provider data answer 401 with a `WWW-Authenticate: Bearer` challenge on the call, not on the connection. Owning a workspace, adding a payment method and turning production on are also human steps. None of that is a condition of connecting, which is what the marker describes, and there is precedent in the list: several 🔓 entries take payment for individual calls.
- **Glama connector:** https://glama.ai/mcp/connectors/com.trustycap/trustycap, badge on the second line as the format asks.

Placed alphabetically in Cloud Platforms, between Render and Vercel.
