### PR TITLE
Add Comunicate.top 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [BizIntel](https://mcp-bizintel-production.up.railway.app) `https://mcp-bizintel-production.up.railway.app/mcp`
   [![BizIntel MCP connector](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bch1212/bizintel)
   🔓 - Audit websites, score local-business leads, detect technology stacks, and find businesses missing websites or booking systems.
+- [Comunicate.top](https://comunicate.top/en/mcp) `https://app.comunicate.top/mcp`
+  [![Comunicate.top MCP connector](https://glama.ai/mcp/connectors/top.comunicate/publishing/badges/score.svg)](https://glama.ai/mcp/connectors/top.comunicate/publishing)
+  🔐 - Publish press releases and advertorials on 3,800+ news sites: search the catalogue, check prices, order publication.
 - [DABLOCK AI Visibility Index](https://dablock.ai) `https://dablock.ai/mcp`
   [![DABLOCK MCP connector](https://glama.ai/mcp/connectors/ai.dablock/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dablock/visibility-index)
   🔓 - Weekly share of answer for 24 crypto and Web3 brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.


### PR DESCRIPTION
Adds **Comunicate.top** under Marketing, alphabetically between BizIntel and DABLOCK.

Remote MCP server, Streamable HTTP at `https://app.comunicate.top/mcp`. OAuth 2.1 with PKCE and dynamic client registration (RFC 7591), so a client registers itself; an API key also works. An unauthenticated request returns 401 with `WWW-Authenticate: Bearer resource_metadata="https://app.comunicate.top/.well-known/oauth-protected-resource/mcp"`.

Twenty tools: search a catalogue of 3,800+ publications by niche, domain authority, price and turnaround; read and write article drafts; check an article against SEO and campaign-type rules; order publication and read back the live URL; campaigns, balance and reports.

- Glama connector: https://glama.ai/mcp/connectors/top.comunicate/publishing
- Official MCP registry: `top.comunicate/publishing`, domain-verified namespace
- Docs and `server.json`: https://github.com/adrianncraciun-cmd/public-mcp

Repository starred, as CONTRIBUTING asks.