### PR TITLE
Add Superpowers.social to Social Media 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
   🔓 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
+- [Superpowers.social](https://superpowers.social) `https://superpowers.social/mcp`
+  [![Superpowers.social MCP connector](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers/badges/score.svg)](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers)
+  🔓 - Read-only search and retrieval of live X/Twitter and Reddit posts, threads, users, and subreddits.
 
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 


### PR DESCRIPTION
**Server:** Superpowers.social — hosted, read-only MCP for X/Twitter and Reddit (10 tools: search, single post, thread, user timeline, trending news; subreddit posts, post with comments, user posts and comments).
**Endpoint:** `https://superpowers.social/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request (anonymous, Streamable HTTP)
- [x] Entry is in the correct category (Social Media), in alphabetical order (after Social Fetch)
- [x] Entry has its Glama connector badge on the second line (`social.superpowers/social-superpowers`)
- [x] Auth marker matches what the endpoint actually does (🔓 — anonymous access with a per-IP daily quota; optional API keys raise the limit)

Moved here from punkpeye/awesome-mcp-servers#13418 at the maintainer's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)