### PR TITLE
Add SceneF - California + Hawaii movie showtimes (Multimedia) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Pixly](https://pixly.app) `https://pixly.app/api/mcp`
   [![Pixly MCP connector](https://glama.ai/mcp/connectors/app.pixly/pixly/badges/score.svg)](https://glama.ai/mcp/connectors/app.pixly/pixly)
   🔓 - Stage, declutter, and enhance real-estate listing photos, and turn them into listing videos.
+- [SceneF](https://scenef.com/agents) `https://scenef.com/mcp`
+  [![SceneF MCP connector](https://glama.ai/mcp/connectors/com.scenef/showtimes/badges/score.svg)](https://glama.ai/mcp/connectors/com.scenef/showtimes)
+  🔓 - Movie showtimes across 33 California and Hawaii boards, re-verified against each theater's own calendar.
 
 ### 💳 <a name="payments"></a>Payments
 


### PR DESCRIPTION
Adds SceneF to Multimedia (alphabetical, after Pixly).

Endpoint: `https://scenef.com/mcp` — Streamable HTTP, no authentication, public and usable by anyone. Glama connector: `com.scenef/showtimes` (badge included). Also in the official MCP registry under the same name.

SceneF is movie showtimes across 33 regional boards in California and Hawaii — repertory houses, single-screen neighborhood theaters, 35mm/70mm prints, and the chains — every showtime re-verified against the theater's own calendar, with a public accuracy record that includes the checks that failed (https://scenef.com/api/accuracy). Nine read-only tools; every tool takes a region. Docs: https://scenef.com/agents and https://scenef.com/llms.txt

Moved here from punkpeye/awesome-mcp-servers#12043 per the local/remote split; the local stdio package is resubmitted there separately.
