### PR TITLE
Add Ryze AI (Google Ads, Meta Ads, GA4, Search Console remote MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Company logos, brand colors, and firmographic data by domain.
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
+- [Ryze AI](https://www.get-ryze.ai) `https://connector.get-ryze.ai/mcp`
+  🔐 - Google Ads, Meta Ads, GA4 and Search Console in one connector: audits, reports, keyword research, budget and bid changes with approval, plus SEO and AI-visibility data.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 


### PR DESCRIPTION
Remote MCP server at `https://connector.get-ryze.ai/mcp` (OAuth 2.1 with dynamic client registration + PKCE; metadata at https://connector.get-ryze.ai/.well-known/oauth-authorization-server).

Connects Claude, ChatGPT, Cursor, Claude Code and Grok to the user's own Google Ads, Meta Ads, GA4 and Search Console. Read tools for audits, reports, keyword research and AI-referral traffic; write tools require approval in chat.

Listed in the official MCP registry as `io.github.irinabuht12-oss/google-meta-ads-ga4-mcp` v1.1.0. Glama listing: https://glama.ai/mcp/servers/irinabuht12-oss/google-meta-ads-ga4-mcp (claim + score in progress). Moved here from awesome-mcp-servers#13183 as requested.