### PR TITLE
Add the Glama connector badge to Flash 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![docs2mcp MCP connector](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp)
   🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.
 - [Flash](https://flashmemorize.com) `https://flashmemorize.com/mcp`
+  [![Flash MCP connector](https://glama.ai/mcp/connectors/com.flashmemorize/flash/badges/score.svg)](https://glama.ai/mcp/connectors/com.flashmemorize/flash)
   🔐 - Spaced-repetition flashcards: create cards from notes, get quizzed by voice, and let FSRS schedule reviews.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)


### PR DESCRIPTION
Follow-up to #112: Flash is now claimed and healthy on Glama (com.flashmemorize/flash), so this adds the connector badge line to the existing entry. No other changes.