### PR TITLE
🤖🤖🤖 Add cn-intel-mcp: China hard-tech supply-chain intel remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Web scraping and SERP data through a managed proxy network.
 - [Cloudflare Radar](https://radar.cloudflare.com) `https://radar.mcp.cloudflare.com/mcp`
   🔐 - Internet traffic, routing, and security trends from Cloudflare Radar.
+- [cn-intel-mcp](https://github.com/lory69060/cn-intel-mcp) `https://cn-intel-mcp.lory69060.workers.dev/mcp`
+  🔑 - China hard-tech supply-chain intel: 33 verifiable signals with falsifiable track record (predicted_on/verify_by/result), earnings tracker, and Q&A research across semiconductors, solid-state batteries, eVTOL, and innovative drugs.
 - [Exa](https://exa.ai) `https://mcp.exa.ai/mcp`
   [![Exa MCP connector](https://glama.ai/mcp/connectors/ai.exa/exa/badges/score.svg)](https://glama.ai/mcp/connectors/ai.exa/exa)
   🔓 - Neural web search that returns full page contents.


### PR DESCRIPTION
Add cn-intel-mcp to the remote MCP servers list.

**Endpoint:** `https://cn-intel-mcp.lory69060.workers.dev/mcp`
**Auth:** 🔑 Bearer token (public sign-up available)
**Transport:** Streamable HTTP

China hard-tech supply-chain intelligence MCP server with:
- 33 verifiable signals (predicted_on/verify_by/result) with falsifiable track record
- 2026 H1 earnings tracker (7 companies, akshare-verified)
- ask_edge Q&A for edge/contrarian research
- Research articles on semiconductors, solid-state batteries, eVTOL, innovative drugs

Glama connector submitted: pending review.