### PR TITLE
Add VetAgent — pre-trade crypto token risk check (Finance) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vantage](https://vantagemcp.dev) `https://vantagemcp.dev/mcp`
   [![Vantage MCP connector](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vantagemcp/vantage)
   🔐 - Ask questions about cloud cost and usage data.
+- [VetAgent](https://vetagent.dev) `https://vetagent.dev/mcp`
+  [![VetAgent MCP connector](https://glama.ai/mcp/connectors/dev.vetagent/vetagent/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vetagent/vetagent)
+  🔓 - Pre-trade crypto token risk check: sell simulation, taxes, liquidity depth, pair age, and published error rates.
 - [Finology Software](https://finology.tech/developers/) `https://mcp.finology.tech/mcp`
   🔑 - US federal student loan payments, forgiveness timing and tax, cited to primary sources.
 


### PR DESCRIPTION
Moved from [awesome-mcp-servers#13873](https://github.com/punkpeye/awesome-mcp-servers/pull/13873) — closed with the note that remote servers belong here now. Thanks for pointing me over.

**Entry** — 💰 Finance, alphabetically after Vantage:

```
- [VetAgent](https://vetagent.dev) `https://vetagent.dev/mcp`
  [![VetAgent MCP connector](https://glama.ai/mcp/connectors/dev.vetagent/vetagent/badges/score.svg)](https://glama.ai/mcp/connectors/dev.vetagent/vetagent)
  🔓 - Pre-trade crypto token risk check: sell simulation, taxes, liquidity depth, pair age, and published error rates.
```

**Against the checklist in CONTRIBUTING.md:**

- **Public URL, answers `initialize`** — `https://vetagent.dev/mcp`, Streamable HTTP, verified just now: `{"name":"vetagent","version":"0.2.0"}`, protocol `2025-03-26`.
- **Usable by anyone** — free, no signup, no API key, no per-user endpoint. 🔓 is accurate.
- **Glama connector** — [`dev.vetagent/vetagent`](https://glama.ai/mcp/connectors/dev.vetagent/vetagent), badge on line 2.
- **Homepage, not the repo** — links to `vetagent.dev`. Source is MIT at [jakegu1/vetagent](https://github.com/jakegu1/vetagent) if useful.
- **Alphabetical** — after Vantage. I left the existing `Finology Software` entry where it is rather than reordering someone else's line in my PR.
- **Description** — 112 characters, one sentence, ends in a period.
- Repo starred.

**What it does:** three tools — `assess_token_risk`, `get_token_liquidity`, `find_new_hot_pools`. The verdict is `low` / `medium` / `high` / `unknown`, and `unknown` means a check could not complete rather than "probably fine" — the tool description says so explicitly, because an agent reading a missing answer as a safe one is the failure that costs a user money.

Accuracy is published rather than asserted: 4.3% false positives on 162 healthy tokens, 15.3% unknown, measured over n=576 with labels from a source the engine never reads, and the harness is in the repo so the numbers can be re-run. The unflattering ones are published too — dead-token recall is 10%, and that is stated first on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)