### PR TITLE
Add Pairoa remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Elicitly](https://www.elicitly.ai) `https://mcp.elicitly.ai/mcp`
   [![Elicitly MCP connector](https://glama.ai/mcp/connectors/ai.elicitly/pro/badges/score.svg)](https://glama.ai/mcp/connectors/ai.elicitly/pro)
   🔐 - Human-in-the-loop for AI agents: confirmations, forms, and durable approvals that reach any device, with an audit trail.
+- [Pairoa](https://pairoa.com) `https://mcp.pairoa.com`
+  [![Pairoa MCP connector](https://glama.ai/mcp/connectors/com.pairoa.mcp/pairoa/badges/score.svg)](https://glama.ai/mcp/connectors/com.pairoa.mcp/pairoa)
+  🔐 - Publish needs and offers through your AI and get private matches, with contact details revealed only on a match.
 
 ### 🎨 <a name="art--design"></a>Art & Design
 


### PR DESCRIPTION
**Server:** Pairoa
**Endpoint:** https://mcp.pairoa.com

Adds Pairoa under Agreements & Coordination, following the maintainer invitation in https://github.com/punkpeye/awesome-mcp-servers/pull/7650#issuecomment-5580506751.

Pairoa is a hosted Streamable HTTP MCP service: users publish needs and offers through their AI, receive private matches, and get contact details only on a match. It uses OAuth with an anonymous start; no user API key is required.

Validation on 2026-09-09:
- The unauthenticated `initialize` request returns HTTP 401 with `WWW-Authenticate: Bearer` and `resource_metadata`, matching this repository's OAuth endpoint check.
- The canonical Glama connector now reports **Healthy** after an authenticated connection test, and its score badge returns HTTP 200.
- The README change adds only the three-line entry; the endpoint is not already listed.

Connection instructions: https://pairoa.com/install
Public integration documentation: https://github.com/pairoa/docs
Glama connector: https://glama.ai/mcp/connectors/com.pairoa.mcp/pairoa

- [x] The endpoint is public and answers an MCP `initialize` request (OAuth challenge when unauthenticated)
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does
