### PR TITLE
Add GreenCalculus to Environment 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ambee](https://ambeedata.com) `https://api-mcp-server.ambeedata.com/mcp`
   [![Ambee MCP connector](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee/badges/score.svg)](https://glama.ai/mcp/connectors/com.ambeedata.api-mcp-server/mcp-ambee)
   🔓 - Weather, air quality, pollen, and other environmental data.
+- [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
+  [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
+  🔑 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.
 - [GridHub](https://grid-hub.app/developers) `https://api.grid-hub.app/mcp`
   [![GridHub MCP connector](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub)
   🔓 - Live and historical electricity prices and demand for 25 grid zones (US, EU, GB, AU); free sample mode, key, or x402.

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Weather, air quality, pollen, and other environmental data.
 - [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
   [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
-  🔑 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.
+  🔓 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.
 - [GridHub](https://grid-hub.app/developers) `https://api.grid-hub.app/mcp`
   [![GridHub MCP connector](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub)
   🔓 - Live and historical electricity prices and demand for 25 grid zones (US, EU, GB, AU); free sample mode, key, or x402.


### PR DESCRIPTION
Adds GreenCalculus under 🌳 Environment, between Ambee and GridHub.

```
- [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
  [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
  🔑 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.
```

Sourced greenhouse-gas emission factors with full provenance — every value comes back with its exact source cell and a pinned data version, so an agent hands back a number a person can cite and a machine can reproduce. 16,673 factors, 12 tools, plus standards-based calculation engines (GHG Protocol activity, EN 15978 embodied carbon, PCAF financed emissions).

Checked against CONTRIBUTING before opening:

- **Reachable + answers `initialize`** — `POST https://mcp.greencalculus.com` returns 200 with `protocolVersion: 2025-06-18`.
- **Usable by anyone** — public self-serve sign-up, free tier, no card.
- **Streamable HTTP** ✅
- **Glama connector** — [`com.greencalculus/api`](https://glama.ai/mcp/connectors/com.greencalculus/api), ownership verified; badge returns 200.
- **Marker** — 🔑 rather than 🔓: the endpoint does accept anonymous connections and `search_factors` / `explain_absence` answer without a key, but the other ten tools need one, so 🔑 seemed the honest call. Happy to switch it to 🔓 if you'd rather flag the keyless path.
- **Ordering** — alphabetical, case-insensitive: Ambee → GreenCalculus → GridHub.
- Repo starred.

Arrived here from #13862 on `awesome-mcp-servers` — thanks for the pointer to the new list.