### PR TITLE
Add SNACS (Finance) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Shingou](https://shingou.io) `https://api.shingou.io/mcp`
   [![Shingou MCP connector](https://glama.ai/mcp/connectors/io.shingou/sentiment/badges/score.svg)](https://glama.ai/mcp/connectors/io.shingou/sentiment)
   🔓 - Hourly news sentiment and typed market events for 30 crypto pairs, source links on every signal, a published hash for every hour of history; data tools need a free key.
+- [SNACS](https://snacs.trade/api) `https://mcp.snacs.trade`
+  [![SNACS MCP connector](https://glama.ai/mcp/connectors/trade.snacs.mcp/snacstrade/badges/score.svg)](https://glama.ai/mcp/connectors/trade.snacs.mcp/snacstrade)
+  🔐 - SEC filings and dilution forensics, market data, news, and fundamentals for U.S. equities with point-in-time queries.
 - [StackEasy](https://www.stackeasy.ai/mcp) `https://data.stackeasy.ai/mcp`
   [![StackEasy MCP connector](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards/badges/score.svg)](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards)
   🔐 - Your own credit cards in your AI: balances, utilization, best card for a purchase, and missed rewards, read only.


### PR DESCRIPTION
Adds SNACS under Finance. Remote MCP server (Streamable HTTP, OAuth 2.1 with dynamic client registration) at `https://mcp.snacs.trade`: SEC filings and dilution forensics, market data, news, and fundamentals for U.S. equities, with point-in-time as-of queries across 14 tools. Product page: https://snacs.trade/api. Glama connector: https://glama.ai/mcp/connectors/trade.snacs.mcp/snacstrade (rated A, ownership verified).

Moved here from punkpeye/awesome-mcp-servers#11917 per the maintainer's note that remote servers now live in this list.