### PR TITLE
Sense2: add Glama connector badge 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
 - [Sense2](https://sense2.com.au) `https://sense2.com.au/api/mcp`
+  [![Sense2 MCP connector](https://glama.ai/mcp/connectors/io.github.24seagull-beep/sense2-catalogue/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.24seagull-beep/sense2-catalogue)
   🔓 - Search 4,000+ Australian promotional products, get quantity-break quotes, browse categories and case studies.
 - [Stienhardt Diamond MCP](https://stienhardt.com/agents.md?utm_source=awesome_remote_mcp&utm_medium=directory&utm_campaign=diamond_mcp) `https://diamond-mcp.stienhardt.workers.dev/mcp`
   🔓 - Diamond education, grading-report guidance, face-up size estimates, and read-only jewelry catalog search.


### PR DESCRIPTION
Adds the Glama connector badge to the existing Sense2 entry (E-Commerce). Connector: https://glama.ai/mcp/connectors/io.github.24seagull-beep/sense2-catalogue (Healthy, TDQS A). Follow-up to #117 per the connector-check comment.