### PR TITLE
Add FrontDesko (Travel & Transportation) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.
+- [FrontDesko](https://frontdesko.app) `https://mcp.frontdesko.app/mcp`
+  [![FrontDesko MCP connector](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp)
+  🔓 - Hotel PMS pricing and plan comparisons, OTA-commission savings math, docs search, and live demo-hotel availability.
 
 ### 🔄 <a name="version-control"></a>Version Control
 


### PR DESCRIPTION
Adds [FrontDesko](https://frontdesko.app)'s official remote MCP server to Travel & Transportation.

- Endpoint: `https://mcp.frontdesko.app/mcp` (Streamable HTTP, no auth 🔓)
- Six read-only tools: hotel PMS pricing/packaging, comparisons with other PMSs, OTA-commission savings calculator, docs search, plan recommendations, and live availability on a public demo hotel
- Glama connector: [io.github.anmols/frontdesko-mcp](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp) (rated A, endpoint responding)
- Placed alphabetically after Alice Flights

Resubmitted from punkpeye/awesome-mcp-servers#12639, which was closed when remote servers moved to this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLgzHFuQGhcwgHviS5NJQA