### PR TITLE
Add Memra to Knowledge & Memory 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.
+- [Memra](https://usememra.com) `https://usememra.com/mcp`
+  [![Memra MCP connector](https://glama.ai/mcp/connectors/com.usememra/memra/badges/score.svg)](https://glama.ai/mcp/connectors/com.usememra/memra)
+  🔑 - Persistent long-term memory for agents: store, semantically recall, and supersede facts, decisions, and patterns.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`


### PR DESCRIPTION
Adding **Memra** — a remote MCP server for persistent agent memory. Coming over from punkpeye/awesome-mcp-servers#9260, where the maintainer pointed me here since Memra is a hosted endpoint rather than a local server.

```markdown
- [Memra](https://usememra.com) `https://usememra.com/mcp`
  [![Memra MCP connector](https://glama.ai/mcp/connectors/com.usememra/memra/badges/score.svg)](https://glama.ai/mcp/connectors/com.usememra/memra)
  🔑 - Persistent long-term memory for agents: store, semantically recall, and supersede facts, decisions, and patterns.
```

## What it does

Memra gives an agent memory that outlives the session: store facts, decisions and reusable patterns, recall them by semantic search, and supersede an outdated memory so the stale version stops surfacing while the audit trail survives. Seven tools — `memra_remember`, `memra_recall`, `memra_get`, `memra_list`, `memra_supersede`, `memra_history`, `memra_bootstrap`. EU-hosted (Hetzner Helsinki).

## Checklist

- **Public URL, answers `initialize`** — `https://usememra.com/mcp` returns `serverInfo` for memra 4.7.1 over Streamable HTTP, anonymously. `tools/list` also answers anonymously, so the handshake and tool-listing checks pass without credentials.
- **Usable by anyone** — public sign-up at usememra.com, no invite needed. Single shared endpoint, not a per-user URL.
- **Streamable HTTP** — no local process.
- **Glama connector** — `com.usememra/memra`, badge on line 2.
- **Auth** — 🔑, an API key sent as `Authorization: Bearer <token>`. Tool *calls* need the key; discovery does not.
- **Ordering** — alphabetical in Knowledge & Memory, between Hugging Face and Notion.
- Repo starred.

## One note on the Glama badge

The connector currently scores as unhealthy. The cause was on our side and is now fixed and deployed: `POST /mcp` answered discovery anonymously, but `GET /mcp` returned `401` with `WWW-Authenticate: Bearer`, which sent Streamable-HTTP clients into an OAuth discovery we don't serve, so they failed the whole connection instead of skipping the optional stream. As of today that GET returns `405` with `Allow: POST`, per the transport spec:

```
GET  /mcp            -> 405, Allow: POST   (was 401 + WWW-Authenticate)
GET  /mcp/sse        -> 401                (legacy transport, unchanged)
POST /mcp initialize -> 200                (unchanged)
POST /mcp tools/call -> 401                (unchanged, still needs a key)
```

The badge should turn healthy on Glama's next hourly pass. Happy to hold this PR until it does if you'd rather see it green first.