### PR TITLE
Add sitectrl (Content Management) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Query and mutate Sanity datasets and documents.
 - [sitectrl](https://sitectrl.ai/mcp) `https://mcp.sitectrl.ai/mcp`
   [![sitectrl MCP connector](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl/badges/score.svg)](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl)
-  🔐 - Build, edit, and publish a hosted website with SSL, contact forms, and first-party analytics.
+  🔓 - Build, edit, and publish a hosted website with SSL, contact forms, and analytics; sign in with OAuth.
 - [Storyblok](https://storyblok.com) `https://mcp.storyblok.com/mcp`
   🔓 - Manage Storyblok spaces, stories, and components.
 - [Webflow](https://webflow.com) `https://mcp.webflow.com/mcp`

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Sanity](https://sanity.io) `https://mcp.sanity.io/mcp`
   [![Sanity MCP connector](https://glama.ai/mcp/connectors/io.sanity.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.sanity.www/mcp)
   🔐 - Query and mutate Sanity datasets and documents.
+- [sitectrl](https://sitectrl.ai/mcp) `https://mcp.sitectrl.ai/mcp`
+  [![sitectrl MCP connector](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl/badges/score.svg)](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl)
+  🔐 - Build, edit, and publish a hosted website with SSL, contact forms, and first-party analytics.
 - [Storyblok](https://storyblok.com) `https://mcp.storyblok.com/mcp`
   🔓 - Manage Storyblok spaces, stories, and components.
 - [Webflow](https://webflow.com) `https://mcp.webflow.com/mcp`

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Query and mutate Sanity datasets and documents.
 - [sitectrl](https://sitectrl.ai/mcp) `https://mcp.sitectrl.ai/mcp`
   [![sitectrl MCP connector](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl/badges/score.svg)](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl)
-  🔓 - Build, edit, and publish a hosted website with SSL, contact forms, and analytics; sign in with OAuth.
+  🔓 - Describe a site and get it live with SSL, forms, and analytics — no account needed; OAuth to edit and manage.
 - [Storyblok](https://storyblok.com) `https://mcp.storyblok.com/mcp`
   🔓 - Manage Storyblok spaces, stories, and components.
 - [Webflow](https://webflow.com) `https://mcp.webflow.com/mcp`


### PR DESCRIPTION
Adding sitectrl — a remote MCP server that builds and hosts real websites from a plain-language description.

```
- [sitectrl](https://sitectrl.ai/mcp) `https://mcp.sitectrl.ai/mcp`
  [![sitectrl MCP connector](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl/badges/score.svg)](https://glama.ai/mcp/connectors/ai.sitectrl/sitectrl)
  🔐 - Build, edit, and publish a hosted website with SSL, contact forms, and first-party analytics.
```

Checklist against CONTRIBUTING.md:

- **Reachable at a public URL** — `https://mcp.sitectrl.ai/mcp` answers `initialize` (protocol `2025-06-18`, HTTP 200).
- **Usable by anyone** — free tier, one site, no card.
- **Streamable HTTP** — declared in our `server.json`.
- **Listed as a Glama connector** — `ai.sitectrl/sitectrl`, ownership verified via `/.well-known/glama.json`.
- **Badge present and resolving** — connector badge included above.
- **Homepage link, not a GitHub repo** — links to `https://sitectrl.ai/mcp`.
- **Alphabetical placement** — between Sanity and Storyblok in Content Management, case-insensitive.
- **Description** — 93 characters.
- **Repo starred.**

Auth is 🔐: OAuth 2.1 with dynamic client registration and PKCE. An unauthenticated `/mcp` returns 401 with `WWW-Authenticate` pointing at `/.well-known/oauth-protected-resource`.

Also listed in the official MCP Registry as `ai.sitectrl/sitectrl`.

Context: this was previously opened as punkpeye/awesome-mcp-servers#13254 and closed with a pointer here, since sitectrl is a hosted server rather than local/stdio.

🤖🤖🤖 in the title per the automated-agent convention in CONTRIBUTING.md.