### PR TITLE
Add UseMyContext to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
 - [UseMyContext](https://usemycontext.ai) `https://mcp.usemycontext.ai/mcp`
-  🔐 - One profile and files you own, read by any MCP client, so you never re-introduce yourself to an AI again.
+  [![UseMyContext MCP connector](https://glama.ai/mcp/connectors/io.github.usemycontext/usemycontext/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.usemycontext/usemycontext)
+  🔓 - Your own profile and files, read by any MCP client. OAuth unlocks your context; anonymous gets metadata only.
 - [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
   🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.
+- [UseMyContext](https://usemycontext.ai) `https://mcp.usemycontext.ai/mcp`
+  🔐 - One profile and files you own, read by any MCP client, so you never re-introduce yourself to an AI again.
 - [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
   🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.


### PR DESCRIPTION
You invited this one over from awesome-mcp-servers#10442. Thanks for the pointer.

- **Homepage:** https://usemycontext.ai
- **Endpoint:** `https://mcp.usemycontext.ai/mcp`
- **Transport:** Streamable HTTP
- **Auth:** OAuth 2.1 (we are the authorization server), so the OAuth marker
- **Category:** Knowledge & Memory, placed alphabetically between Rootr and Vilix AI

Checked against CONTRIBUTING.md:

- [x] Reachable at a public URL and answers an MCP `initialize` request. Verified just now unauthenticated: returns `protocolVersion 2025-06-18` and `serverInfo.name "UseMyContext.ai"`. Anonymous callers get the static metadata methods only; every other call returns the OAuth 401 trigger.
- [x] Usable by anyone, public sign-up. There is also a shared public demo account if you want to look inside without signing up.
- [x] Speaks Streamable HTTP.
- [x] One shared endpoint, not a per-user URL. The project is resolved from a claim in the token.
- [x] Description is one sentence, 105 characters.
- [x] Starred the repo.

One note on the badge: we are a Glama connector already (`io.github.usemycontext/usemycontext`, currently reading healthy), but I left the badge line off to match the plainer entries in this section like Notion and Flash. Happy to add it in a follow-up commit if you would rather every new entry carried one.

What it does: it serves one person's own profile and files to any MCP client, so they stop re-introducing themselves to every new AI. Read-only over the drive, and the public front doors hold no data bindings by design.