### PR TITLE
Add MemoryPlugin 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.
+- [MemoryPlugin](https://www.memoryplugin.com) `https://www.memoryplugin.com/api/mcp/mcp`
+  [![MemoryPlugin MCP connector](https://glama.ai/mcp/connectors/com.memoryplugin/memory/badges/score.svg)](https://glama.ai/mcp/connectors/com.memoryplugin/memory)
+  🔐 - Store, search, and recall long-term memories shared across ChatGPT, Claude, Gemini, and 21+ AI tools.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`


### PR DESCRIPTION
Adds MemoryPlugin to Knowledge & Memory (alphabetical position, after Hugging Face).

- Hosted remote MCP server at `https://www.memoryplugin.com/api/mcp/mcp` (Streamable HTTP, OAuth 2.0 with PKCE + dynamic client registration; public sign-up).
- Glama connector: [com.memoryplugin/memory](https://glama.ai/mcp/connectors/com.memoryplugin/memory) — badge resolves.
- Endpoint answers `initialize` (verified today).

Context: this replaces punkpeye/awesome-mcp-servers#11507, closed when hosted servers moved to this list.

Disclosure: opened on behalf of the maker of MemoryPlugin, by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8iJVjzuc995B9rqJkkziz