### PR TITLE
Add HAIDAA to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.
 - [Flash](https://flashmemorize.com) `https://flashmemorize.com/mcp`
   🔐 - Spaced-repetition flashcards: create cards from notes, get quizzed by voice, and let FSRS schedule reviews.
+- [HAIDAA](https://haidaa.com/mcp) `https://mcp.haidaa.com/mcp`
+  [![HAIDAA MCP connector](https://glama.ai/mcp/connectors/com.haidaa.mcp/haidaa/badges/score.svg)](https://glama.ai/mcp/connectors/com.haidaa.mcp/haidaa)
+  🔓 - Search signed scientific claims, methods, provenance, contradictions, retractions, and admission receipts.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.


### PR DESCRIPTION
**Server:** [HAIDAA](https://haidaa.com/mcp)
**Endpoint:** `https://mcp.haidaa.com/mcp`

Adds HAIDAA to Knowledge & Memory. Its public Streamable HTTP endpoint provides anonymous, read-only access to search and inspect signed scientific claims, methods, observations, artifacts, provenance, contradictions, retractions, and reproducible admission receipts.

The Glama connector is claimed and evaluated, with a working grade A badge. The endpoint returned HTTP 200 for an unauthenticated MCP `initialize` request, and `tools/list` returned eight tools.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Resubmitted here following the maintainer's remote-server migration request in https://github.com/punkpeye/awesome-mcp-servers/pull/13799.
