### PR TITLE
Add FlightPowers Google Flights and Booking.com Hotels 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.
+- [FlightPowers Booking.com Hotels](https://hotels.flightpowers.com) `https://hotels.flightpowers.com/mcp/oauth`
+  [![FlightPowers Booking.com Hotels MCP connector](https://glama.ai/mcp/connectors/com.flightpowers/booking/badges/score.svg)](https://glama.ai/mcp/connectors/com.flightpowers/booking)
+  🔐 - Live Booking.com room rates by destination or hotel name, priced per country through residential proxies.
+- [FlightPowers Google Flights](https://flights.flightpowers.com) `https://flights.flightpowers.com/mcp/oauth`
+  [![FlightPowers Google Flights MCP connector](https://glama.ai/mcp/connectors/com.flightpowers/google-flights/badges/score.svg)](https://glama.ai/mcp/connectors/com.flightpowers/google-flights)
+  🔐 - Live Google Flights fares with price band and verdict, round trips in one request, date ranges and destination lists.
 
 ### 🔄 <a name="version-control"></a>Version Control
 


### PR DESCRIPTION
Two hosted travel servers I run, added under Travel & Transportation, alphabetically after Alice Flights.

punkpeye closed https://github.com/punkpeye/awesome-mcp-servers/pull/13359 and pointed me here, so this is that entry plus the hotels one.

**Server:** FlightPowers Google Flights
**Endpoint:** `https://flights.flightpowers.com/mcp/oauth`

**Server:** FlightPowers Booking.com Hotels
**Endpoint:** `https://hotels.flightpowers.com/mcp/oauth`

Both are OAuth 2.1 sign-in and return 401 with `WWW-Authenticate: Bearer resource_metadata=...` to an unauthenticated `initialize`. Each also keeps a key-based URL for existing users (`https://flights.flightpowers.com/mcp` and `https://hotels.flightpowers.com/mcp` with an `x-rapidapi-key` header), but the OAuth URL is the one worth listing.

Flights: live Google Flights fares with the price band and low/typical/high verdict, round trips priced as paired legs in one request, date ranges and destination lists in one call. Source: https://github.com/mtnrabi/google-flights-mcp
Hotels: live Booking.com rates by destination or by hotel name, with `proxy_country` for per-country pricing.

Billing runs on the user's own RapidAPI plan. Public sign-up, no invite needed.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does
