### PR TITLE
Add Nomado24 to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [LiveDataLink](https://livedatalink.ai) `https://livedatalink.ai/mcp`
   [![LiveDataLink MCP connector](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink)
   🔓 - Query 294 tools across 60 public-data domains, spanning sanctions, courts, markets, health, energy, and government.
+- [Nomado24](https://www.nomado24.de/en/developers) `https://api.nomado24.de/api/public/v1/mcp`
+  [![Nomado24 MCP connector](https://glama.ai/mcp/connectors/de.nomado24/jobs/badges/score.svg)](https://glama.ai/mcp/connectors/de.nomado24/jobs)
+  🔓 - Search live remote and hybrid jobs in Germany and Europe.
 - [Realask](https://realask.net) `https://realask.net/mcp`
   [![Realask MCP connector](https://glama.ai/mcp/connectors/io.github.danelas/realask/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.danelas/realask)
   🔓 - Verify facts about US local businesses by phone — stock, all-in price, availability — as typed answers with evidence.


### PR DESCRIPTION
## What

Adds Nomado24 under Search & Data Extraction: a remote, streamable-HTTP
MCP server over the nomado24 index of remote and hybrid jobs for Germany
and the EU. No authentication, public endpoint, free to use with
attribution.

## Checklist against CONTRIBUTING.md

- Reachable at a public URL, answers `initialize`:
  `https://api.nomado24.de/api/public/v1/mcp`.
- Usable by anyone, no sign-up.
- Streamable HTTP, POST only, stateless.
- Glama connector badge: already listed and healthy at
  `glama.ai/mcp/connectors/de.nomado24/jobs` (auto-discovered through the
  official MCP Registry entry `de.nomado24/jobs`, published 2026-08-02).
- Alphabetical placement: between LiveDataLink and Realask.

## Context

This server was previously submitted to the sibling repo
(punkpeye/awesome-mcp-servers#11332), which was closed by the bot because
that list is for locally-run servers and this one is a hosted remote
endpoint, with a pointer to this repo instead. This PR is that follow-up.

Left as a draft for review before merge.