### PR TITLE
Add Company Check to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AlphaPipeline](https://alphapipeline-eu.onrender.com) `https://alphapipeline-eu.onrender.com/mcp`
   [![AlphaPipeline MCP connector](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp)
   🔓 - Crypto trading data for AI agents: Polymarket prediction-market arbitrage, kimchi premium alerts, on-chain token-unlock risk, token security scans, funding rates, and webpage-to-Markdown conversion; x402 pay-per-call in USDC on Base, no signup.  
+- [Company Check — UK, Sweden & Norway business registers](https://api.foretak.dev) `https://api.foretak.dev/mcp`
+  🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   🔓 - Historical return data for funds and tickers.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![AlphaPipeline MCP connector](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp)
   🔓 - Crypto trading data for AI agents: Polymarket prediction-market arbitrage, kimchi premium alerts, on-chain token-unlock risk, token security scans, funding rates, and webpage-to-Markdown conversion; x402 pay-per-call in USDC on Base, no signup.  
 - [Company Check](https://api.foretak.dev) `https://api.foretak.dev/mcp`
+  [![Company Check MCP connector](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp)
   🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AlphaPipeline](https://alphapipeline-eu.onrender.com) `https://alphapipeline-eu.onrender.com/mcp`
   [![AlphaPipeline MCP connector](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp)
   🔓 - Crypto trading data for AI agents: Polymarket prediction-market arbitrage, kimchi premium alerts, on-chain token-unlock risk, token security scans, funding rates, and webpage-to-Markdown conversion; x402 pay-per-call in USDC on Base, no signup.  
-- [Company Check — UK, Sweden & Norway business registers](https://api.foretak.dev) `https://api.foretak.dev/mcp`
+- [Company Check](https://api.foretak.dev) `https://api.foretak.dev/mcp`
   🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)


### PR DESCRIPTION
Adds `Company Check` to Finance, alphabetically (between `AlphaPipeline` and `Fruit Stand`). No existing company-registry entry in the list.

MCP server + REST API over three national business registers, one JSON shape per country. Live today:

- **United Kingdom** (Companies House): company lookup by company number, registered status and address, plus filing history, its register of charges (mortgages and other security interests) and any insolvency proceedings.
- **Norway** (Brønnøysundregistrene / Enhetsregisteret): company lookup by organisasjonsnummer, plus filing history.
- **Sweden** (Bolagsverket): company lookup by organisationsnummer, plus filing history.

All calls also return each company's statutory filing deadlines, citing the provision or register field behind the date.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [ ] Entry has its Glama connector badge on the second line — **not yet added.** The server isn't listed at glama.ai/mcp/connectors (a separate product from glama.ai/mcp/servers, where it already carries a score badge); that submission needs a human on Glama's own claim flow. Will push the badge line as a follow-up commit once the connector exists — fine for this PR to wait on that rather than merge without one.
- [x] Auth marker matches what the endpoint actually does (🔓, no key, no account)

MIT-licensed; register data stays under each register's own terms (Companies House open data; NLOD 2.0 for Norway; Bolagsverket's published terms for Sweden), attributed on every response. Repo: https://github.com/foretak/registry-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAuijZcEso5sz28SatyAYf
