### PR TITLE
Add Roamzy — global eSIM over MCP (Travel & Transportation) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.
 
+- [Roamzy](https://roamzy.io) `https://roamzy.io/mcp`
+  [![Roamzy MCP connector](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server)
+  🔓 - Buy and manage one global eSIM for 193 countries, billed per megabyte in USDT or USDC — no account, no signup, no KYC.
+
 ### 🔄 <a name="version-control"></a>Version Control
 
 - [GitHub](https://github.com) `https://api.githubcopilot.com/mcp/`


### PR DESCRIPTION
Moved here from [awesome-mcp-servers#11559](https://github.com/punkpeye/awesome-mcp-servers/pull/11559) on your note that remote servers get their own list — thanks for the pointer.

**Roamzy** is one global eSIM for 193 countries, billed per megabyte at the destination's local rate and settled in USDT or USDC. No packages, no validity windows, no expiry.

Against the four requirements in CONTRIBUTING:

- **Public URL, answers `initialize`.** `https://roamzy.io/mcp`, Streamable HTTP. I ran your CI's probe verbatim against it: `{"ok":true,"auth":"🔓","status":200,"server":{"name":"roamzy","version":"1.6.9"}}`.
- **Usable by anyone.** Anonymous-first: no account, no API key and no KYC to browse *or* to buy — an anonymous account is minted on the first tool call. That is why `🔓` is the honest marker rather than a paywall behind the handshake; OAuth exists but is optional, so the endpoint never answers 401.
- **Streamable HTTP**, no local process. (There is an npm package for stdio clients too; that one belongs in the other list.)
- **Glama connector**: [`io.github.roamzy-io/mcp-server`](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server) — 12 tools, rated A, endpoint healthy. `connectorExists()` returns `true`.

Placed in **Travel & Transportation**, alphabetically after Alice Flights. One entry, three lines, description 118 characters ending in a period. I also ran your workflow's own parser over the diff: auth marker recognised, no unknown markers, badge slug resolves, endpoint not a duplicate.

Repo starred. Server source: [roamzy-io/mcp-server](https://github.com/roamzy-io/mcp-server) (MIT).