### PR TITLE
Add Xpoz to Social Media 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [Social Fetch](https://www.socialfetch.dev) `https://api.socialfetch.dev/mcp`
   🔓 - Hosted MCP for a social media scraping API: public profiles, posts, comments, and transcripts, live on every request.
+- [Xpoz](https://xpoz.ai) `https://mcp.xpoz.ai/mcp`
+  [![Xpoz MCP connector](https://glama.ai/mcp/connectors/ai.xpoz/social-insights/badges/score.svg)](https://glama.ai/mcp/connectors/ai.xpoz/social-insights)
+  🔐 - Search Twitter/X, Instagram, Reddit and TikTok: posts, profiles, comments, followers, and tracking.
 
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 


### PR DESCRIPTION
Adds Xpoz to the Social Media section.

Xpoz is a hosted MCP server for reading public social data: Twitter/X, Instagram, Reddit and TikTok. 52 tools for keyword and hashtag search, user profiles, posts, comments, follower connections, and tracking.

Against the checklist:

- Endpoint: `https://mcp.xpoz.ai/mcp`, Streamable HTTP, answers `initialize` anonymously.
- Auth: OAuth (🔐), public sign-up, free tier.
- Glama connector: https://glama.ai/mcp/connectors/ai.xpoz/social-insights, ownership verified via DNS, 52 tools introspected, tool definitions rated A.

Note for context: the same server was submitted to awesome-mcp-servers as #10098, which was closed for inactivity while waiting on a Glama repo-page quality score. That score cannot be assigned to a remote-only server (no local build, so no tools to introspect), and per the CONTRIBUTING scope rule the server belongs on this list instead. Happy to adjust the entry if anything is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnVYz9AmN5bthq1J6DYxi1