### PR TITLE
Add Lampions — French and European parliamentary vote tallies 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
   [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
   🔓 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
+- [Lampions](https://lampions.org) `https://lampions.org/mcp`
+  🔓 - Official tallies of public votes in the French National Assembly, Senate and European Parliament, with the bill title, a plain-language question, ayes/noes/abstentions, outcome, source and licence. No personal data.
 - [LiveDataLink](https://livedatalink.ai) `https://livedatalink.ai/mcp`
   [![LiveDataLink MCP connector](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink)
   🔓 - Query 294 tools across 60 public-data domains, spanning sanctions, courts, markets, health, energy, and government.


### PR DESCRIPTION
Adds **Lampions** under 🔎 Search & Data Extraction, in alphabetical order (after GovAuctions.app).

- Endpoint: `https://lampions.org/mcp` — Streamable HTTP, no authentication
- Two read-only tools: `lire_scrutin` (one official vote by its official id) and `derniers_scrutins` (recent major votes, filterable by chamber and topic)
- Source data: French National Assembly open data, Senate DOSLEG base, European Parliament roll-call votes — all under the French Open Licence (Etalab). No personal data is exposed.

The `initialize` handshake answers with protocol `2025-06-18`. The server is also published in the official MCP registry as `org.lampions/scrutins`.

Verification:

```bash
curl -s -X POST https://lampions.org/mcp \
  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}'
```

🤖 Opened by an automated agent, per CONTRIBUTING.md.