### PR TITLE
Add ConnectMachine to CRM 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Read and update Close leads, contacts, and opportunities.
 - [ConnectMachine](https://www.connectmachine.ai) `https://mcp.connectmachine.ai/mcp`
   [![ConnectMachine MCP connector](https://glama.ai/mcp/connectors/ai.connectmachine/connectmachine/badges/score.svg)](https://glama.ai/mcp/connectors/ai.connectmachine/connectmachine)
-  🔐 - Manage ConnectMachine contacts, networks, events, and digital business cards.
+  🔑 - Manage ConnectMachine contacts, networks, events, and digital business cards.
 - [HubSpot](https://hubspot.com) `https://mcp.hubspot.com/anthropic`
   🔐 - Query and update HubSpot CRM contacts, companies, and deals.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Close](https://close.com) `https://mcp.close.com/mcp`
   [![Close MCP connector](https://glama.ai/mcp/connectors/com.close/close-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.close/close-mcp)
   🔐 - Read and update Close leads, contacts, and opportunities.
+- [ConnectMachine](https://www.connectmachine.ai) `https://mcp.connectmachine.ai/mcp`
+  [![ConnectMachine MCP connector](https://glama.ai/mcp/connectors/ai.connectmachine/connectmachine/badges/score.svg)](https://glama.ai/mcp/connectors/ai.connectmachine/connectmachine)
+  🔐 - Manage ConnectMachine contacts, networks, events, and digital business cards.
 - [HubSpot](https://hubspot.com) `https://mcp.hubspot.com/anthropic`
   🔐 - Query and update HubSpot CRM contacts, companies, and deals.
 


### PR DESCRIPTION
Adds **ConnectMachine** under CRM.

- **Endpoint:** `https://mcp.connectmachine.ai/mcp` (Streamable HTTP)
- **Auth:** OAuth 2.1 with Dynamic Client Registration and PKCE → 🔐
- **Glama connector:** https://glama.ai/mcp/connectors/ai.connectmachine/connectmachine
- **Registry:** published to the official MCP Registry as `ai.connectmachine/connectmachine`, DNS-verified namespace

ConnectMachine is a digital business-card and contact platform. The server exposes 48 tools across contacts, networks, events, cards, meeting transcripts, and imports — all scoped to the caller's own account (every tool is annotated `openWorldHint: false`).

Public sign-up is open, so the endpoint is usable by anyone with an account. Placed after Close and before HubSpot to keep the category alphabetical.