### PR TITLE
Add HOTLIKESHOP MCP server (E-Commerce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![AMZ Vault MCP connector](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault/badges/score.svg)](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault)
   🔐 - Run an Amazon seller brand from chat: profit analytics, PPC, inventory forecasting, listings, staged approvals.
 - [HOTLIKESHOP](https://hotlikeshop.com) `https://hotlikeshop.com/api/mcp`
+  [![HOTLIKESHOP MCP connector](https://glama.ai/mcp/connectors/com.hotlikeshop/hotlikeshop-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.hotlikeshop/hotlikeshop-mcp)
   🔓 - Buy real MMO / social-media accounts, proxies and digital services: search the catalog, check balance, get quotes and place orders in-chat.
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AMZ Vault](https://www.amz-vault.com) `https://www.amz-vault.com/mcp`
   [![AMZ Vault MCP connector](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault/badges/score.svg)](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault)
   🔐 - Run an Amazon seller brand from chat: profit analytics, PPC, inventory forecasting, listings, staged approvals.
+- [HOTLIKESHOP](https://hotlikeshop.com) `https://hotlikeshop.com/api/mcp`
+  🔓 - Buy real MMO / social-media accounts, proxies and digital services: search the catalog, check balance, get quotes and place orders in-chat.
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
 - [Sense2](https://sense2.com.au) `https://sense2.com.au/api/mcp`


### PR DESCRIPTION
Adds **HOTLIKESHOP** under E-Commerce (alphabetical, after AMZ Vault).

Moving this over from awesome-mcp-servers as requested — it is a remote (hosted) server, so it belongs here.

- Website: https://hotlikeshop.com
- Endpoint: https://hotlikeshop.com/api/mcp (remote, Streamable HTTP)
- Auth: connect anonymously (no key required for lookup tools)
- Glama: previously evaluated grade A, claimed by maintainer, remote-capable

Lets an AI client search a real e-commerce marketplace (MMO / social-media accounts, proxies and digital services), check balance, get quotes, and place orders in-chat. Entry follows the existing format. Thanks!