### PR TITLE
Add SnowSignals TrendVane (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - SEC filings and dilution forensics, market data, news, and fundamentals for U.S. equities with point-in-time queries.
 - [SnowSignals TrendVane](https://snowsignals.io) `https://snowsignals.io/mcp`
   [![SnowSignals TrendVane MCP connector](https://glama.ai/mcp/connectors/io.snowsignals/snowsignals/badges/score.svg)](https://glama.ai/mcp/connectors/io.snowsignals/snowsignals)
-  🔐 - Market-phase (TrendVane) state per currency across timeframes, plus phase-resolution stats. Reports state, not trade signals.
+  🔓 - Market-phase (TrendVane) state per currency across timeframes; free metadata and phase-resolution stats, live reads metered. Reports state, not trade signals.
 - [StackEasy](https://www.stackeasy.ai/mcp) `https://data.stackeasy.ai/mcp`
   [![StackEasy MCP connector](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards/badges/score.svg)](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards)
   🔐 - Your own credit cards in your AI: balances, utilization, best card for a purchase, and missed rewards, read only.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [SNACS](https://snacs.trade/api) `https://mcp.snacs.trade`
   [![SNACS MCP connector](https://glama.ai/mcp/connectors/trade.snacs.mcp/snacstrade/badges/score.svg)](https://glama.ai/mcp/connectors/trade.snacs.mcp/snacstrade)
   🔐 - SEC filings and dilution forensics, market data, news, and fundamentals for U.S. equities with point-in-time queries.
+- [SnowSignals TrendVane](https://snowsignals.io) `https://snowsignals.io/mcp`
+  [![SnowSignals TrendVane MCP connector](https://glama.ai/mcp/connectors/io.snowsignals/snowsignals/badges/score.svg)](https://glama.ai/mcp/connectors/io.snowsignals/snowsignals)
+  🔐 - Market-phase (TrendVane) state per currency across timeframes, plus phase-resolution stats. Reports state, not trade signals.
 - [StackEasy](https://www.stackeasy.ai/mcp) `https://data.stackeasy.ai/mcp`
   [![StackEasy MCP connector](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards/badges/score.svg)](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards)
   🔐 - Your own credit cards in your AI: balances, utilization, best card for a purchase, and missed rewards, read only.


### PR DESCRIPTION
Adds **SnowSignals TrendVane** to the Finance category (alphabetical, between Shingou and StackEasy).

- **Endpoint:** `https://snowsignals.io/mcp` (streamable HTTP, 🔐 OAuth)
- **What it is:** a remote MCP server exposing TrendVane, a multi-timeframe market-phase model over a metered API. It reports market *state* (which phase a currency is in per timeframe), plus phase-resolution statistics — not trade signals.
- **Glama connector:** ownership-verified via DNS, TDQS **A**, endpoint healthy. Badge included per the legend and resolves at `https://glama.ai/mcp/connectors/io.snowsignals/snowsignals/badges/score.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6B83YjRGPaN5GzfYLEzh8