### PR TITLE
Add Gridbert to Environment 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
   [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
   🔓 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.
+- [Gridbert](https://www.gridbert.at) `https://mcp.gridbert.at/mcp`
+  [![Gridbert MCP connector](https://glama.ai/mcp/connectors/at.gridbert/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/at.gridbert/mcp)
+  🔐 - Austrian household electricity: compare tariffs, validate invoices, and analyze smart meter load profiles.
 - [GridHub](https://grid-hub.app/developers) `https://api.grid-hub.app/mcp`
   [![GridHub MCP connector](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub)
   🔓 - Live and historical electricity prices and demand for 25 grid zones (US, EU, GB, AU); free sample mode, key, or x402.


### PR DESCRIPTION
Adds **Gridbert** to Environment, between Ambee and GridHub.

Gridbert is a remote MCP server for Austrian household electricity. The tools compare tariffs against a nightly-refreshed catalogue of Austrian suppliers, validate a scanned electricity invoice deterministically (no LLM arithmetic — every euro figure comes back with its calculation path), and analyze smart meter quarter-hour load profiles obtained through the Austrian EDA consent process.

- **Endpoint:** `https://mcp.gridbert.at/mcp` — Streamable HTTP.
- **Auth:** OAuth 2.1 (🔐). Unauthenticated requests get `401` with a `WWW-Authenticate: Bearer` challenge pointing at `https://mcp.gridbert.at/.well-known/oauth-protected-resource`.
- **Sign-up:** public, at https://www.gridbert.at.
- **Glama connector:** [`at.gridbert/mcp`](https://glama.ai/mcp/connectors/at.gridbert/mcp), badge included in the entry.

Context: this was previously submitted as punkpeye/awesome-mcp-servers#11259 and closed on 2026-09-08 with a pointer to this list. Following that pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
