### PR TITLE
Add Onplana to Project Management 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Manage Linear issues, projects, and cycles.
 - [monday.com](https://monday.com) `https://mcp.monday.com/mcp`
   🔐 - Manage monday.com boards, items, and updates.
+- [Onplana](https://onplana.com) `https://mcp.onplana.com/mcp`
+  🔐 - Manage Onplana projects, tasks, sprints, risks, and portfolios, with Microsoft Project file import.
 - [Stellary](https://stellary.co) `https://api.stellary.co/mcp`
   [![Stellary MCP connector](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management)
   🔐 - AI-native project boards, cockpit, and governed agent missions over hosted Streamable HTTP.

--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [monday.com](https://monday.com) `https://mcp.monday.com/mcp`
   🔐 - Manage monday.com boards, items, and updates.
 - [Onplana](https://onplana.com) `https://mcp.onplana.com/mcp`
+  [![Onplana MCP connector](https://glama.ai/mcp/connectors/io.github.Onplana/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Onplana/mcp-server)
   🔐 - Manage Onplana projects, tasks, sprints, risks, and portfolios, with Microsoft Project file import.
 - [Stellary](https://stellary.co) `https://api.stellary.co/mcp`
   [![Stellary MCP connector](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Anymfah/stellary-project-management)


### PR DESCRIPTION
Adds Onplana, a hosted project and portfolio management MCP server, to the Project Management section.

```
- [Onplana](https://onplana.com) `https://mcp.onplana.com/mcp`
  🔐 - Manage Onplana projects, tasks, sprints, risks, and portfolios, with Microsoft Project file import.
```

Placed alphabetically between monday.com and Stellary. One entry, two lines, no other changes.

**Remote, not local.** The endpoint is operated by us at `https://mcp.onplana.com/mcp` over Streamable HTTP. There is no package to install, which is why this is here rather than in awesome-mcp-servers.

**Handshake check.** `POST /mcp` with an `initialize` request returns `401` carrying RFC 9728 discovery, so an MCP client can find the authorization server:

```
www-authenticate: Bearer realm="onplana",
  resource_metadata="https://mcp.onplana.com/.well-known/oauth-protected-resource"
```

OAuth 2.1 with dynamic client registration and PKCE, hence 🔐. Onplana is already listed in the official MCP Registry as `io.github.Onplana/mcp-server`, and the server template and TypeScript client are open source at [Onplana/onplana-mcp-server](https://github.com/Onplana/onplana-mcp-server) (MIT).

Disclosure: I am the vendor. Title carries the agent opt-in per CONTRIBUTING.
