### PR TITLE
Add magento.watch to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ionic Framework MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/ionic-framework/) `https://ionic-framework-mcp.capawesome.io/mcp`
   [![Ionic Framework MCP connector](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp)
   🔓 - Unofficial: search the Ionic Framework docs for v8 and v9, with the component API and usage examples.
+- [magento.watch](https://magento.watch/mcp) `https://magento.watch/mcp/api`
+  🔓 - Check whether a Magento, Adobe Commerce or Mage-OS version is supported, when it goes end-of-life, and what it needs.
 - [mumo](https://mumo.chat) `https://mumo.chat/api/mcp`
   [![mumo MCP connector](https://glama.ai/mcp/connectors/chat.mumo/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/chat.mumo/mcp)
   🔓 - A frontier panel for your agent: Ask Claude, GPT, Grok, and more. Get their independent responses *and* reactions to each other. See what they agree with, challenge, or want to explore further — in their own words. For architecture, plan/spec review, and strategy.


### PR DESCRIPTION
Moved here from punkpeye/awesome-mcp-servers#12528, per the close notice on that PR — magento.watch is a hosted remote server, so it belongs on this list.

```
- [magento.watch](https://magento.watch/mcp) `https://magento.watch/mcp/api`
  🔓 - Check whether a Magento, Adobe Commerce or Mage-OS version is supported, when it goes end-of-life, and what it needs.
```

## What the tools do

Version lifecycle lookup for the Magento ecosystem. For every Magento Open Source, Adobe Commerce and Mage-OS release the server exposes the release date, the end-of-life date, and the supported version ranges for PHP, Composer, MySQL, MariaDB, OpenSearch, Elasticsearch, Redis/Valkey, RabbitMQ, Varnish, nginx and the matching AWS managed services. 6 tools and 3 resources. The questions it answers are the ones that gate an upgrade: is this version still getting patches, when does support end, and what does the target version require.

## Against the requirements

- **Reachable at a public URL** — `https://magento.watch/mcp/api` answers `initialize`:
  ```
  {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","serverInfo":{"name":"magento-watch","version":"1.0.0"},"capabilities":{"tools":{},"resources":{}}}}
  ```
- **Usable by anyone** — no sign-up, no key, no tenant-specific URL. Read-only and free, hence the `🔓` marker.
- **Streamable HTTP** — single endpoint, no local process. `GET https://magento.watch/mcp/api` returns the server descriptor; docs at https://magento.watch/mcp.
- **Placement** — Developer Tools, alphabetically between `Ionic Framework MCP Server by Capawesome` and `mumo`. E-Commerce looked plausible, but the tools serve developers planning upgrades rather than anyone operating a store.
- **Starred** the repository.

## One gap

No Glama connector badge yet — the connector is not listed at glama.ai/mcp/connectors. I have left the badge line off rather than pointing it at a connector that does not resolve, since CI checks that. Happy to add it in this PR once the connector is up if you would rather wait for it.