### PR TITLE
Add MemorySync and MemorySync Documentation remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search models, datasets, and Spaces, and call Space APIs.
 - [MemorySync](https://memorysync.io) `https://mcp.memorysync.io/mcp`
   [![MemorySync MCP connector](https://glama.ai/mcp/connectors/io.memorysync/memory/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/memory)
-  🔑 - Scoped, persistent memory layer for AI agents and LLM applications to save, inspect, and recall decisions across sessions.
+  🔐 - Scoped, persistent memory layer for AI agents and LLM applications to save, inspect, and recall decisions across sessions.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`

--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ionic Framework MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/ionic-framework/) `https://ionic-framework-mcp.capawesome.io/mcp`
   [![Ionic Framework MCP connector](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp)
   🔓 - Unofficial: search the Ionic Framework docs for v8 and v9, with the component API and usage examples.
+- [MemorySync Documentation](https://docs.memorysync.io/mcp/overview) `https://docs.memorysync.io/mcp`
+  [![MemorySync Docs MCP connector](https://glama.ai/mcp/connectors/io.memorysync/docs/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/docs)
+  🔓 - Search and read MemorySync's API, SDK, and integration documentation from an MCP-compatible coding assistant.
 - [mumo](https://mumo.chat) `https://mumo.chat/api/mcp`
   [![mumo MCP connector](https://glama.ai/mcp/connectors/chat.mumo/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/chat.mumo/mcp)
   🔓 - A frontier panel for your agent: Ask Claude, GPT, Grok, and more. Get their independent responses *and* reactions to each other. See what they agree with, challenge, or want to explore further — in their own words. For architecture, plan/spec review, and strategy.
@@ -373,6 +376,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
   🔓 - Search models, datasets, and Spaces, and call Space APIs.
+- [MemorySync](https://memorysync.io) `https://mcp.memorysync.io/mcp`
+  [![MemorySync MCP connector](https://glama.ai/mcp/connectors/io.memorysync/memory/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/memory)
+  🔑 - Scoped, persistent memory layer for AI agents and LLM applications to save, inspect, and recall decisions across sessions.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`


### PR DESCRIPTION
Adds MemorySync remote MCP servers:
- MemorySync (Knowledge & Memory): persistent context & decision memory layer with OAuth/API key auth
- MemorySync Documentation (Developer Tools): unauthenticated documentation search & read tools

Both servers are verified on Glama with active connector badges and streamable HTTP endpoints.

<!--
Adding a remote MCP server? Keep the entry in this shape and delete the rest of this comment.

- [Name](https://homepage.example) `https://mcp.example.com/mcp`
  [![Name MCP connector](https://glama.ai/mcp/connectors/com.example/name/badges/score.svg)](https://glama.ai/mcp/connectors/com.example/name)
  🔐 - One sentence describing what the tools do.

Auth: 🔓 none · 🔑 API key · 🔐 OAuth
-->

**Server:**
**Endpoint:**

- [ ] The endpoint is public and answers an MCP `initialize` request
- [ ] Entry is in the correct category, in alphabetical order
- [ ] Entry has its Glama connector badge on the second line
- [ ] Auth marker matches what the endpoint actually does
