### PR TITLE
Add Post Bridge (Social Media) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Publish and schedule posts across social networks.
 - [Post Bridge](https://www.post-bridge.com/mcp) `https://www.post-bridge.com/api/mcp/mcp`
   [![Post Bridge MCP connector](https://glama.ai/mcp/connectors/io.github.jackfriks/post-bridge/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jackfriks/post-bridge)
-  🔐 - Publish and schedule to Instagram, TikTok, YouTube, X, LinkedIn, Facebook, Pinterest, Threads, Bluesky and Google Business, with media upload and analytics.
+  🔐 - Publish, schedule and analyze posts across ten platforms, from Instagram and TikTok to LinkedIn and Bluesky.
 - [PostLake](https://postlake.dev) `https://api.postlake.dev/mcp`
   [![PostLake MCP connector](https://glama.ai/mcp/connectors/dev.postlake/social/badges/score.svg)](https://glama.ai/mcp/connectors/dev.postlake/social)
   🔐 - Publish, schedule, and read analytics across X, LinkedIn, Instagram, TikTok, Facebook, Threads, Bluesky, YouTube, and Pinterest from one hosted MCP server.

--- a/README.md
+++ b/README.md
@@ -533,6 +533,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [OmniSocials](https://omnisocials.com) `https://mcp.omnisocials.com/`
   [![OmniSocials MCP connector](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials/badges/score.svg)](https://glama.ai/mcp/connectors/com.omnisocials.mcp/omni-socials)
   🔑 - Publish and schedule posts across social networks.
+- [Post Bridge](https://www.post-bridge.com/mcp) `https://www.post-bridge.com/api/mcp/mcp`
+  [![Post Bridge MCP connector](https://glama.ai/mcp/connectors/io.github.jackfriks/post-bridge/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jackfriks/post-bridge)
+  🔐 - Publish and schedule to Instagram, TikTok, YouTube, X, LinkedIn, Facebook, Pinterest, Threads, Bluesky and Google Business, with media upload and analytics.
 - [PostLake](https://postlake.dev) `https://api.postlake.dev/mcp`
   [![PostLake MCP connector](https://glama.ai/mcp/connectors/dev.postlake/social/badges/score.svg)](https://glama.ai/mcp/connectors/dev.postlake/social)
   🔐 - Publish, schedule, and read analytics across X, LinkedIn, Instagram, TikTok, Facebook, Threads, Bluesky, YouTube, and Pinterest from one hosted MCP server.


### PR DESCRIPTION
Adds [Post Bridge](https://www.post-bridge.com/mcp) to Social Media, alphabetical between OmniSocials and PostLake.

- Endpoint: `https://www.post-bridge.com/api/mcp/mcp` (Streamable HTTP, OAuth 2.0 with dynamic client registration; anonymous `initialize` returns 401 with `WWW-Authenticate` resource metadata, same as the other 🔐 entries)
- Public sign-up, MCP included on every plan, 7-day free trial
- Glama connector: https://glama.ai/mcp/connectors/io.github.jackfriks/post-bridge (ownership verified)
- 14 tools: create, schedule, update, delete posts; media upload by URL or upload link; connected accounts; per-platform results; analytics
- Also listed in the Claude connector directory and as a ChatGPT plugin

Follow-up to punkpeye/awesome-mcp-servers#11158, where you pointed us here for hosted endpoints. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8QXwFMmCK8mA6SDZmW9ws