### PR TITLE
Add MeshKore to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Hubris](https://hubris.pw) `https://api.hubris.pw/mcp`
   [![Hubris MCP connector](https://glama.ai/mcp/connectors/pw.hubris.api/hubris/badges/score.svg)](https://glama.ai/mcp/connectors/pw.hubris.api/hubris)
   🔐 - Catalogue of 500+ LLMs with ruble pricing, account balance, and chat completions with parity to /v1/chat/completions.
+- [MeshKore](https://meshkore.com) `https://mcp.meshkore.com/v1/mcp`
+  [![MeshKore MCP connector](https://glama.ai/mcp/connectors/com.meshkore/meshkore/badges/score.svg)](https://glama.ai/mcp/connectors/com.meshkore/meshkore)
+  🔓 - Find a live agent by describing the task, then call its skills; availability is probe-verified, not self-reported.
 - [minia2a](https://minia2a.uk) `https://minia2a.uk/mcp`
   [![minia2a MCP connector](https://glama.ai/mcp/connectors/uk.minia2a/minia2a-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/uk.minia2a/minia2a-mcp)
   🔓 - 1,600+ pay-per-call APIs — crypto data, web scraping, AI inference, token security — USDC on Base via x402.


### PR DESCRIPTION
Moving this over from awesome-mcp-servers per @punkpeye's note on punkpeye/awesome-mcp-servers#13279. MeshKore is hosted, so it fits here rather than there.

**Endpoint:** `https://mcp.meshkore.com/v1/mcp` (Streamable HTTP, no auth).

MeshKore is an agent network. Three tools: `search_agents` (natural-language query), `list_skills`, and `call_agent`, which reads the target's A2A card at `/.well-known/agent.json` and POSTs to the skill URL it declares. So one tool reaches any agent on the network, with no per-agent integration.

The entry leads with the probe rather than the catalogue size, since anyone can claim a big index. Agents are re-probed on a schedule and only reported operational when their advertised skills answer, so `call_agent` refuses a dead one up front instead of failing at the call.

- [x] Public URL, `initialize` returns 200
- [x] Open to anyone (🔓, no signup, no key)
- [x] Streamable HTTP
- [x] Glama connector: [`com.meshkore/meshkore`](https://glama.ai/mcp/connectors/com.meshkore/meshkore), rated A
- [x] Alphabetical in Aggregators (after Hubris, before minia2a)
- [x] Starred the repo

Description is 114 characters. Source is MIT: https://github.com/meshkore/mcp