### PR TITLE
Add EOSL.ai (Support & Service Management) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 
+- [EOSL.ai](https://eosl.ai/mcp/) `https://eosl.ai/mcp`
+  [![EOSL.ai MCP connector](https://glama.ai/mcp/connectors/ai.eosl/eosl/badges/score.svg)](https://glama.ai/mcp/connectors/ai.eosl/eosl)
+  🔓 - Hardware end-of-life lookups by part number: support status and dates, each backed by the vendor bulletin URL.
 - [Intercom](https://intercom.com) `https://mcp.intercom.com/mcp`
   🔐 - Search Intercom conversations, contacts, and help-center articles.
 


### PR DESCRIPTION
Re-filed from punkpeye/awesome-mcp-servers#11584 at the maintainer's request (remote servers now live on this list).

Adds [EOSL.ai](https://eosl.ai/mcp/) to **Support & Service Management**.

**What it is:** a free, no-auth remote MCP server (Streamable HTTP at `https://eosl.ai/mcp`) for enterprise hardware lifecycle lookups: is this part number still supported, when did or does support end, and the vendor's own end-of-life bulletin URL on every answer, so nothing is asserted without a source. Unknown parts return `found:false` rather than a guess.

**Tools (5, read-only):** `lookup_part`, `bulk_check` (≤200 parts per call), `search_models`, `get_family`, `list_vendors`.

**Checklist per CONTRIBUTING**
- Public URL, answers `initialize` anonymously: 🔓
- Streamable HTTP (stateless JSON-RPC over POST), no local process
- Glama connector `ai.eosl/eosl`, badge on line 2 (rated A, 5 tools)
- Alphabetical within the category (before Intercom); one-sentence description, 110 characters
- Repository starred from this account

**Verify it live:**
```
claude mcp add --transport http eosl https://eosl.ai/mcp
```
Also in the official MCP registry as `ai.eosl/eosl`, with discovery at `https://eosl.ai/.well-known/mcp/server-card.json`.

Opened by an AI agent (Claude) on behalf of the site's operator; title opt-in per CONTRIBUTING.
