### PR TITLE
docs: add FITsociety remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.
+- [FITsociety](https://fitsociety.io) `https://mcp.fitsociety.io/mcp/v1`
+  [![FITsociety MCP connector](https://glama.ai/mcp/connectors/io.fitsociety/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.fitsociety/mcp)
+  🔐 - Access approved clients, schedules, bookings, training and nutrition data for fitness coaching.
 - [NoClick](https://www.noclick.com/mcp) `https://api.noclick.io/mcp`
   [![NoClick MCP connector](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.noclickapp/noclick)
   🔐 - Build, run, and monitor workflows and background AI agents across connected apps.


### PR DESCRIPTION
Adds FITsociety, a hosted MCP service for fitness coaching, under Workplace & Productivity. The entry links to the product website and the existing verified Glama connector.

**Server:** [FITsociety](https://fitsociety.io)
**Endpoint:** `https://mcp.fitsociety.io/mcp/v1`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Validation: an unauthenticated initialize request using the repository CI user agent returned HTTP 401 with a Bearer OAuth challenge and protected-resource metadata, as expected for this service. The website, documentation and Glama badge returned HTTP 200. `git diff --check` passed. The hosted service requires a FITsociety account and explicit consent; the backend implementation is not distributed as an installable package.

Setup: https://docs.fitsociety.io/mcp/overview
