### PR TITLE
Add Treza to Multimedia 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [SceneF](https://scenef.com/agents) `https://scenef.com/mcp`
   [![SceneF MCP connector](https://glama.ai/mcp/connectors/com.scenef/showtimes/badges/score.svg)](https://glama.ai/mcp/connectors/com.scenef/showtimes)
   🔓 - Movie showtimes across 33 California and Hawaii boards, re-verified against each theater's own calendar.
+- [Treza](https://www.trezalabs.com/connect) `https://www.trezalabs.com/api/mcp`
+  [![Treza MCP connector](https://glama.ai/mcp/connectors/io.github.treza-labs/treza/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.treza-labs/treza)
+  🔐 - Create, run, and schedule video pipelines that script, render, narrate, caption, and publish to YouTube and TikTok.
 
 ### 💳 <a name="payments"></a>Payments
 


### PR DESCRIPTION
Adds **Treza** to Multimedia.

Refiled from punkpeye/awesome-mcp-servers#13918, which was closed with a pointer to this list because the server is remote rather than stdio. The Glama connector asked for there now exists, so the badge resolves.

**Entry**

- Homepage: https://www.trezalabs.com/connect
- Endpoint: `https://www.trezalabs.com/api/mcp` (Streamable HTTP)
- Auth: OAuth 2.0 with dynamic client registration, so 🔐. An unauthenticated `initialize` returns `401` with a `WWW-Authenticate: Bearer` challenge pointing at `/.well-known/oauth-protected-resource`.
- Glama connector: [io.github.treza-labs/treza](https://glama.ai/mcp/connectors/io.github.treza-labs/treza)

**What the tools do**

16 tools for authoring and running AI video pipelines: create, update and publish a pipeline graph, run it, poll runs, browse node types and templates, estimate run cost, check the credit balance, list connected YouTube/TikTok channels, and pause or resume a schedule. An agent can build a working pipeline from nothing, so no one has to draw one on the canvas first.

Public sign-up, single shared endpoint for every user, no per-user URL.

Checklist from CONTRIBUTING:

- [x] Repository starred
- [x] Public URL that answers `initialize`
- [x] Usable by anyone via public sign-up
- [x] Streamable HTTP
- [x] Listed as a Glama connector, badge included
- [x] Alphabetical within Multimedia