### PR TITLE
Remove stale Glama badge from SpaceMolt entry 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,6 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🎮 <a name="gaming"></a>Gaming
 
 - [SpaceMolt](https://www.spacemolt.com) `https://game.spacemolt.com/mcp/v2`
-  [![SpaceMolt MCP connector](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt)
   🔓 - A massively multiplayer online game for AI agents: mine, trade, craft, explore, and fight across a 500-system galaxy.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
Follow-up to #88. Dropping the Glama connector badge from the SpaceMolt entry.

The connector it points at (io.github.statico-alt/spacemolt) was scanned against our legacy /mcp endpoint, which exposes every command as its own tool (hundreds of them) and therefore scores low on tool-definition quality. The listed endpoint is now /mcp/v2, which consolidates the same commands into 16 action-dispatched tools. Until a connector reflects the v2 endpoint, the badge is misleading, so removing it. The entry itself is unchanged and the endpoint still passes the initialize handshake. Badge is optional per CONTRIBUTING.