### PR TITLE
Add FlightPowers Google Flights (Travel & Transportation) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.
+- [FlightPowers Google Flights](https://flights.flightpowers.com) `https://flights.flightpowers.com/mcp`
+  [![FlightPowers Google Flights MCP connector](https://glama.ai/mcp/connectors/com.flightpowers/google-flights/badges/score.svg)](https://glama.ai/mcp/connectors/com.flightpowers/google-flights)
+  🔐 - Live Google Flights fares with price band and verdict, round trips in one request, date ranges and destination lists.
 - [FrontDesko](https://frontdesko.app) `https://mcp.frontdesko.app/mcp`
   [![FrontDesko MCP connector](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp)
   🔓 - Hotel PMS pricing and plan comparisons, OTA-commission savings math, docs search, and live demo-hotel availability.


### PR DESCRIPTION
Adds [FlightPowers Google Flights](https://flights.flightpowers.com) to Travel & Transportation.

- Endpoint: `https://flights.flightpowers.com/mcp` (Streamable HTTP, OAuth 🔐). An unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://flights.flightpowers.com/.well-known/oauth-protected-resource/mcp"`. Existing users can still pass a key on the same URL via an `x-rapidapi-key` header, so nobody needs a per-user endpoint.
- Tools: live Google Flights fares, one-way and round-trip. Round trips are priced as paired legs in one request, a call takes a date range and a list of destinations, and results carry Google's own price band with a low/typical/high verdict.
- Glama connector: [com.flightpowers/google-flights](https://glama.ai/mcp/connectors/com.flightpowers/google-flights), badge on the second line.
- Placed alphabetically after Alice Flights.
- Public sign-up, no invite. Billing runs on the user's own RapidAPI plan. Source: https://github.com/mtnrabi/google-flights-mcp

Split out of #144 as the triage note asked ("this PR adds multiple servers. Please submit one per PR"). The hotels server is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7YoVpT9aAsAPQTv34ZRdj
