### PR TITLE
Add FlightPowers Booking.com Hotels (Travel & Transportation) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Alice Flights](https://mcp.alice.co.il) `https://mcp.alice.co.il/mcp`
   [![Alice Flights MCP connector](https://glama.ai/mcp/connectors/il.co.alice/flights/badges/score.svg)](https://glama.ai/mcp/connectors/il.co.alice/flights)
   🔐 - Search worldwide flights from Alice, one of Israel's best-known travel apps, including Tel Aviv routes, with English and Hebrew results tagged best, cheapest, and fastest.
+- [FlightPowers Booking.com Hotels](https://hotels.flightpowers.com) `https://hotels.flightpowers.com/mcp`
+  [![FlightPowers Booking.com Hotels MCP connector](https://glama.ai/mcp/connectors/com.flightpowers/booking/badges/score.svg)](https://glama.ai/mcp/connectors/com.flightpowers/booking)
+  🔐 - Live Booking.com room rates by destination or hotel name, priced per country through residential proxies.
 - [FrontDesko](https://frontdesko.app) `https://mcp.frontdesko.app/mcp`
   [![FrontDesko MCP connector](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp)
   🔓 - Hotel PMS pricing and plan comparisons, OTA-commission savings math, docs search, and live demo-hotel availability.


### PR DESCRIPTION
Adds [FlightPowers Booking.com Hotels](https://hotels.flightpowers.com) to Travel & Transportation.

- Endpoint: `https://hotels.flightpowers.com/mcp` (Streamable HTTP, OAuth 🔐). An unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://hotels.flightpowers.com/.well-known/oauth-protected-resource/mcp"`. Existing users can still pass a key on the same URL via an `x-rapidapi-key` header, so nobody needs a per-user endpoint.
- Tools: live Booking.com room rates, searched by destination or by hotel name, with a `proxy_country` parameter that prices the same property from a residential IP in another country for rate-parity checks.
- Glama connector: [com.flightpowers/booking](https://glama.ai/mcp/connectors/com.flightpowers/booking), badge on the second line.
- Placed alphabetically after Alice Flights.
- Public sign-up, no invite. Billing runs on the user's own RapidAPI plan.

Split out of #144 as the triage note asked ("this PR adds multiple servers. Please submit one per PR"). The flights server is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7YoVpT9aAsAPQTv34ZRdj
