### PR TITLE
Add MemorySync remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,10 +397,10 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search signed scientific claims, methods, provenance, contradictions, retractions, and admission receipts.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
+  🔓 - Search models, datasets, and Spaces, and call Space APIs.
 - [MemorySync](https://memorysync.io) `https://mcp.memorysync.io/mcp`
   [![MemorySync MCP connector](https://glama.ai/mcp/connectors/io.memorysync/memory/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/memory)
   🔐 - Scoped, persistent memory layer for AI agents and LLM applications to save, inspect, and recall decisions across sessions.
-  🔓 - Search models, datasets, and Spaces, and call Space APIs.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`

--- a/README.md
+++ b/README.md
@@ -397,6 +397,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search signed scientific claims, methods, provenance, contradictions, retractions, and admission receipts.
 - [Hugging Face](https://huggingface.co) `https://huggingface.co/mcp`
   [![Hugging Face MCP connector](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/co.huggingface/hf-mcp-server)
+- [MemorySync](https://memorysync.io) `https://mcp.memorysync.io/mcp`
+  [![MemorySync MCP connector](https://glama.ai/mcp/connectors/io.memorysync/memory/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/memory)
+  🔐 - Scoped, persistent memory layer for AI agents and LLM applications to save, inspect, and recall decisions across sessions.
   🔓 - Search models, datasets, and Spaces, and call Space APIs.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.


### PR DESCRIPTION
Adds the MemorySync remote MCP server to Knowledge & Memory:
- Endpoint: `https://mcp.memorysync.io/mcp`
- Auth: OAuth 2.0 / Bearer token (🔐)
- Verified Glama connector badge included

<!--
Adding a remote MCP server? Keep the entry in this shape and delete the rest of this comment.

- [Name](https://homepage.example) `https://mcp.example.com/mcp`
  [![Name MCP connector](https://glama.ai/mcp/connectors/com.example/name/badges/score.svg)](https://glama.ai/mcp/connectors/com.example/name)
  🔐 - One sentence describing what the tools do.

Auth: 🔓 none · 🔑 API key · 🔐 OAuth
-->

**Server:**
**Endpoint:**

- [ ] The endpoint is public and answers an MCP `initialize` request
- [ ] Entry is in the correct category, in alphabetical order
- [ ] Entry has its Glama connector badge on the second line
- [ ] Auth marker matches what the endpoint actually does
