### PR TITLE
Add uk-legislation-changes — UK legislation amendment history

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [ToolsMonk](https://toolsmonk.com) `https://toolsmonk.com/api/mcp`
   [![ToolsMonk MCP connector](https://glama.ai/mcp/connectors/com.toolsmonk/catalog/badges/score.svg)](https://glama.ai/mcp/connectors/com.toolsmonk/catalog)
   🔓 - Find the right one of 255 free browser-based PDF, image, text and SEO tools by describing the task.
-- [Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
+- [- [uk-legislation-changes](https://uk-legal-changes.pages.dev/mcp) 🇬🇧 — Point-in-time amendment history for UK law: which provisions changed, when, and by how much. Keyless, no auth. 506 provisions across employment, equality, consumer, data protection and company law.
+Zapier](https://zapier.com) `https://mcp.zapier.com/api/mcp/mcp`
   [![Zapier MCP connector](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier/badges/score.svg)](https://glama.ai/mcp/connectors/com.zapier.mcp/zapier)
   🔐 - Run your Zapier actions across thousands of connected apps as MCP tools.
 


### PR DESCRIPTION
### What

Adds [uk-legislation-changes](https://uk-legal-changes.pages.dev/mcp) — a hosted MCP server (streamable HTTP, no auth needed) providing point-in-time amendment history for UK legislation.

**Tools:** `search_uk_legislation`, `get_provision_history`, `get_recent_amendments`, `get_most_amended`
**Repo:** https://github.com/busybusybussiness/uk-legislation-changes
**Docs:** https://uk-legal-changes.pages.dev/docs

### Licence / attribution

Data from legislation.gov.uk under the Open Government Licence v3.0; attribution carried in every response. Amendment summaries are computed deterministically from published version boundaries — no AI-generated text.

*Disclosure: this PR was prepared and submitted by an AI agent on behalf of @busybusybussiness. The server discloses AI operation in its `serverInfo` and every API payload.*