### PR TITLE
Add Turnale (Sports) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 * 🔎 - [Search & Data Extraction](#search--data-extraction)
 * 🔒 - [Security](#security)
 * 📣 - [Social Media](#social-media)
+* 🏆 - [Sports](#sports)
 * 🎧 - [Support & Service Management](#support--service-management)
 * 🚆 - [Travel & Transportation](#travel--transportation)
 * 🔄 - [Version Control](#version-control)
@@ -588,6 +589,12 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Superpowers.social](https://superpowers.social) `https://superpowers.social/mcp`
   [![Superpowers.social MCP connector](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers/badges/score.svg)](https://glama.ai/mcp/connectors/social.superpowers/social-superpowers)
   🔓 - Read-only search and retrieval of live X/Twitter and Reddit posts, threads, users, and subreddits.
+
+### 🏆 <a name="sports"></a>Sports
+
+- [Turnale](https://www.turnale.app) `https://mcp.turnale.app`
+  [![Turnale MCP connector](https://glama.ai/mcp/connectors/app.turnale/turnale/badges/score.svg)](https://glama.ai/mcp/connectors/app.turnale/turnale)
+  🔓 - Run recreational racket-sport tournaments from chat: draws, schedules, live standings, one-sentence dropout handling.
 
 ### 🎧 <a name="support--service-management"></a>Support & Service Management
 


### PR DESCRIPTION
Adds [Turnale](https://www.turnale.app) — recreational racket-sport tournaments (tennis, padel, pickleball, badminton, squash, table tennis) run from chat: fair draws for americano / mexicano / round robin / groups + playoff / knockout, live standings, conversational score entry, and one-sentence dropout and substitution handling with preview and undo.

Moved here from punkpeye/awesome-mcp-servers#11435, closed with a note that hosted servers now belong in this list.

- Endpoint: `https://mcp.turnale.app` — streamable HTTP, answers `initialize` anonymously
- Auth: 🔓 none
- Glama connector: [app.turnale/turnale](https://glama.ai/mcp/connectors/app.turnale/turnale)
- Adds a **Sports** category (index + section), placed alphabetically between Social Media and Support & Service Management, since nothing existing fits

Submitted by Claude Code on behalf of the Turnale team (hello@turnale.app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)