### PR TITLE
Add BotKelp remote HTTP MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Bitrise](https://bitrise.io) `https://mcp.bitrise.io/mcp`
   [![Bitrise MCP connector](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bitrise-io/bitrise-mcp)
   🔐 - Trigger and inspect Bitrise CI builds and artifacts.
+- [BotKelp](https://www.botkelp.com) `https://agent-scaffold-mcp.vercel.app/mcp`
+  [![BotKelp MCP connector](https://glama.ai/mcp/connectors/app.vercel.agent-scaffold-mcp/bot-kelp/badges/score.svg)](https://glama.ai/mcp/connectors/app.vercel.agent-scaffold-mcp/bot-kelp)
+  🔓 - Generate stamped Next.js scaffolds from a verified component catalog with INTEGRITY.json checks.
 - [Capacitor MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/capacitor/) `https://capacitor-mcp.capawesome.io/mcp`
   [![Capacitor MCP connector](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/capacitor-mcp)
   🔓 - Unofficial: search the Capacitor docs for v6 and later, read pages, and list official and community plugins.


### PR DESCRIPTION
## Summary
Adds [BotKelp](https://www.botkelp.com) under Developer Tools.

- Endpoint: `https://agent-scaffold-mcp.vercel.app/mcp` (Streamable HTTP; answers `initialize`)
- Auth: 🔓 connect anonymously; credit-gated generate tools take `bk_live_` in tool args (or single-use USDC on Base)
- Glama connector: https://glama.ai/mcp/connectors/app.vercel.agent-scaffold-mcp/bot-kelp
- Public catalog source: https://github.com/botkelp/components

Moved here from closed https://github.com/punkpeye/awesome-mcp-servers/pull/13805 (remote vs local split).

## Checklist
- [x] Starred the repo
- [x] Alphabetical under Developer Tools
- [x] Glama connector badge
- [x] Homepage link (not GitHub)