### PR TITLE
Add pSEO Engine to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
 - [pSEO Engine](https://quantumcx.net/pseo-engine) `https://pseo.quantumcx.net/api/agent/mcp`
+  [![pSEO Engine MCP connector](https://glama.ai/mcp/connectors/net.quantumcx/pseo-engine/badges/score.svg)](https://glama.ai/mcp/connectors/net.quantumcx/pseo-engine)
   🔑 - Programmatic SEO as agent tools: turn a query space into a page plan, generate landing pages from it, audit them for answer engines, and publish to a domain you control. Discovery is anonymous; tool calls need an API key.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.

--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Company logos, brand colors, and firmographic data by domain.
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
+- [pSEO Engine](https://quantumcx.net/pseo-engine) `https://pseo.quantumcx.net/api/agent/mcp`
+  🔑 - Programmatic SEO as agent tools: turn a query space into a page plan, generate landing pages from it, audit them for answer engines, and publish to a domain you control. Discovery is anonymous; tool calls need an API key.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
 - [pSEO Engine](https://quantumcx.net/pseo-engine) `https://pseo.quantumcx.net/api/agent/mcp`
   [![pSEO Engine MCP connector](https://glama.ai/mcp/connectors/net.quantumcx/pseo-engine/badges/score.svg)](https://glama.ai/mcp/connectors/net.quantumcx/pseo-engine)
-  🔑 - Programmatic SEO as agent tools: turn a query space into a page plan, generate landing pages from it, audit them for answer engines, and publish to a domain you control. Discovery is anonymous; tool calls need an API key.
+  🔓 - Programmatic SEO as agent tools: turn a query space into a page plan, generate landing pages from it, audit them for answer engines, and publish to a domain you control. Connects anonymously so the tools and their prices can be inspected before committing; running any of them needs an API key.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 


### PR DESCRIPTION
Adds **pSEO Engine** under Marketing.

- Homepage: https://quantumcx.net/pseo-engine
- Endpoint: `https://pseo.quantumcx.net/api/agent/mcp` (Streamable HTTP)

Programmatic SEO as agent tools — research a query space into a page plan, generate landing pages from it, audit them for answer engines, and publish to a domain the user controls.

Checks against the contributing rules:

- **Remote-only**, so it belongs in this list rather than `awesome-mcp-servers` — there is no installable package.
- **Answers an MCP `initialize` handshake anonymously**, so discovery works without credentials:
  ```
  curl -s -X POST https://pseo.quantumcx.net/api/agent/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
  ```
  returns all 9 tools. Tool *calls* need an API key, hence 🔑.
- Placed alphabetically between Mailcoach and Vibe Prospecting.
- Also published to the Official MCP Registry as [`net.quantumcx/pseo-engine`](https://registry.modelcontextprotocol.io/v0/servers?search=pseo-engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)