### PR TITLE
Add JobsPipe remote server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GovAuctions.app](https://govauctions.app) `https://govauctions.app/api/mcp`
   [![GovAuctions.app MCP connector](https://glama.ai/mcp/connectors/app.govauctions/govauctions/badges/score.svg)](https://glama.ai/mcp/connectors/app.govauctions/govauctions)
   🔓 - Search live government surplus auction lots in the US, UK, CA and AU, with sold-price comps and resale scores.
+- [JobsPipe](https://jobspipe.dev) `https://jobspipe.dev/mcp`
+  [![JobsPipe MCP connector](https://glama.ai/mcp/connectors/dev.jobspipe/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.jobspipe/mcp)
+  🔓 - List the ATS and job-board sources JobsPipe normalizes, look up pricing plans, and search live Upwork postings; full job search runs through the keyed REST API.
 - [LiveDataLink](https://livedatalink.ai) `https://livedatalink.ai/mcp`
   [![LiveDataLink MCP connector](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink)
   🔓 - Query 294 tools across 60 public-data domains, spanning sanctions, courts, markets, health, energy, and government.


### PR DESCRIPTION
Adds JobsPipe under Search & Data Extraction.

- Homepage: https://jobspipe.dev
- Endpoint: `https://jobspipe.dev/mcp` (Streamable HTTP, answers `initialize` anonymously)
- Glama connector: https://glama.ai/mcp/connectors/dev.jobspipe/mcp
- Official registry entry: `dev.jobspipe/mcp`

Tools on the anonymous endpoint: list the ATS and job-board sources JobsPipe normalizes, list pricing plans, search live Upwork postings, plus resources for the OpenAPI spec and source catalog. Full job search across the 30+ sources runs through the REST API with a free key (1,000 jobs/month, no card).

Submitted by an automated agent on behalf of the JobsPipe maintainer; opting into the agent fast-track per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FH1ikVc3c8tMvY5Pq1vAR