### PR TITLE
Add Parlel remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [LiveDataLink](https://livedatalink.ai) `https://livedatalink.ai/mcp`
   [![LiveDataLink MCP connector](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.blackboxfoundry/livedatalink)
   🔓 - Query 294 tools across 60 public-data domains, spanning sanctions, courts, markets, health, energy, and government.
+- [Parlel](https://parlel.com) `https://api.parlel.com/mcp`
+  [![Parlel MCP connector](https://glama.ai/mcp/connectors/com.parlel.api/parlel/badges/score.svg)](https://glama.ai/mcp/connectors/com.parlel.api/parlel)
+  🔓 - Search people, companies, and open roles on an open professional network. Free, no API key.
 - [Realask](https://realask.net) `https://realask.net/mcp`
   [![Realask MCP connector](https://glama.ai/mcp/connectors/io.github.danelas/realask/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.danelas/realask)
   🔓 - Verify facts about US local businesses by phone — stock, all-in price, availability — as typed answers with evidence.


### PR DESCRIPTION
Adds Parlel (https://parlel.com) to Search & Data Extraction, alphabetical between LiveDataLink and Realask.

- Endpoint `https://api.parlel.com/mcp`: Streamable HTTP, no auth, answers initialize (verified 200 with serverInfo parlel 1.0.0).
- Glama connector: https://glama.ai/mcp/connectors/com.parlel.api/parlel (badge resolves).
- Official registry: `com.parlel/parlel` v1.0.0.
- 8 read-only tools: search_jobs/get_job, search_companies/get_company, search_people/get_person, search_agents/get_agent.

Disclosure: I maintain this server (filed on behalf of Parlel via automated agent; opted into agent fast-track per CONTRIBUTING).