### PR TITLE
Add Ontonym (Knowledge & Memory) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`
   [![notepad.page MCP connector](https://glama.ai/mcp/connectors/page.notepad/notepad/badges/score.svg)](https://glama.ai/mcp/connectors/page.notepad/notepad)
   🔓 - Persistent private HTML pages for AI agents and their humans: publish, recall, and update living pages with server-side state at a personal address. OAuth unlocks publishing and other protected tools.
+- [Ontonym](https://www.ontonym.com) `https://mcp.ontonym.com/mcp`
+  [![Ontonym MCP connector](https://glama.ai/mcp/connectors/com.ontonym/memory/badges/score.svg)](https://glama.ai/mcp/connectors/com.ontonym/memory)
+  🔐 - Give your agents your team's real data: read the shared graph, and propose actions a human approves.
 - [Rootr](https://rootr.io) `https://rootr.io/mcp`
   [![Rootr MCP connector](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.inspirio-co/rootr-cli)
   🔐 - Read, search, and write a team workspace of documents, tables, spreadsheets, issue trackers, and CRM records, with answers citing the source paragraph.


### PR DESCRIPTION
Adds [Ontonym](https://www.ontonym.com) — a shared, permission-governed graph that agents read and write over MCP.

- Endpoint: `https://mcp.ontonym.com/mcp` (Streamable HTTP)
- Auth: OAuth 2.1 with dynamic client registration (🔐)
- Glama connector: https://glama.ai/mcp/connectors/com.ontonym/memory (synced from the official MCP Registry, `com.ontonym/memory`)
- Public sign-up, same URL for every user

Updated 2026-09-11: rebased on main and re-worded to match our current positioning. Kept in Knowledge & Memory — that is what the server serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)