### PR TITLE
Add bsv.cx 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
   [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
   🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.
+- [bsv.cx](https://bsv.cx) `https://bsv.cx/mcp`
+  [![bsv.cx MCP connector](https://glama.ai/mcp/connectors/cx.bsv/bsv-cx/badges/score.svg)](https://glama.ai/mcp/connectors/cx.bsv/bsv-cx)
+  🔓 - Timestamp and verify evidence on-chain; let your agent prove what it saw and when.
 - [docs2mcp](https://docs2mcp.com) `https://mcp.docs2mcp.com/mcp`
   [![docs2mcp MCP connector](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.docs2mcp/docs2mcp)
   🔐 - Query your own PDFs and documents, with every answer linking to the exact page and region it came from.


### PR DESCRIPTION
Adds **bsv.cx** to Knowledge & Memory.

bsv.cx gives an AI agent verifiable memory: timestamp a hash of any output, archive a web page as it looked, or fetch a URL with a receipt of what came back — each anchored in a Bitcoin SV transaction. Verification is free and trustless; anyone can check the proof against public block headers on any explorer.

- **Endpoint:** `https://bsv.cx/mcp` — Streamable HTTP (stateless), answers MCP `initialize`.
- **Auth:** 🔓 none to start (paid tools settle over HTTP 402).
- **Glama connector:** live at `cx.bsv/bsv-cx` (reverse-DNS id, same as our MCP Registry listing).

Placed alphabetically in Knowledge & Memory.