### PR TITLE
Add Software Sausage remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Razi Tools](https://www.razi.pro/developer) `https://www.razi.pro/api/mcp`
   [![Razi Tools MCP connector](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools)
   🔓 - 28 file and text tools: merge, split and compress PDFs, OCR, image compression, SQL, QR codes, JWTs and mock data.
+- [Software Sausage](https://softwaresausage.com/mcp) `https://softwaresausage.com/api/mcp`
+  [![Software Sausage MCP connector](https://glama.ai/mcp/connectors/io.github.pinkpwningclub/recipes/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.pinkpwningclub/recipes)
+  🔓 - Search independent software options and read-only agent workflows with roles, checks, sources, and safety boundaries.
 - [UI Verify](https://uiverify.ai) `https://uiverify.ai/api/mcp`
   [![UI Verify MCP connector](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify/badges/score.svg)](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify)
   🔓 - Audit a web page for accessibility and layout issues.
@@ -673,5 +676,4 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ## Contributing
 
 Found a remote server that belongs here? See [CONTRIBUTING.md](CONTRIBUTING.md).
-
 

--- a/README.md
+++ b/README.md
@@ -678,3 +678,4 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 Found a remote server that belongs here? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 
+

--- a/README.md
+++ b/README.md
@@ -802,4 +802,3 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 Found a remote server that belongs here? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 
-

--- a/README.md
+++ b/README.md
@@ -677,3 +677,4 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 Found a remote server that belongs here? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+


### PR DESCRIPTION
**Server:** Software Sausage
**Endpoint:** https://softwaresausage.com/api/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Adds the hosted, read-only Software Sausage MCP for independent software discovery and bounded agent workflow recipes.