### PR TITLE
Add Prompeteer remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search and fetch verified KiCad parts (symbol, footprint, 3D model) for AI-assisted PCB design — 21k+ parts, CC-BY-4.0, no account needed.
 - [Postman](https://postman.com) `https://mcp.postman.com/mcp`
   🔐 - Work with Postman collections, environments, and APIs.
+- [Prompeteer](https://prompeteer.ai) `https://prompeteer.ai/mcp`
+  [![Prompeteer MCP connector](https://glama.ai/mcp/connectors/ai.prompeteer/prompeteer/badges/score.svg)](https://glama.ai/mcp/connectors/ai.prompeteer/prompeteer)
+  🔐 - Generates contextual prompts and agent skills for 140+ AI platforms, with a 16-dimension Prompt Score.
 - [Razi Tools](https://www.razi.pro/developer) `https://www.razi.pro/api/mcp`
   [![Razi Tools MCP connector](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools)
   🔓 - 28 file and text tools: merge, split and compress PDFs, OCR, image compression, SQL, QR codes, JWTs and mock data.


### PR DESCRIPTION
**Server:** [Prompeteer](https://prompeteer.ai)
**Endpoint:** `https://prompeteer.ai/mcp`

Generates contextual prompts and agent skills tuned to 140+ AI platforms, with a 16-dimension Prompt Score and a saved prompt vault. Free to start.

Adds the hosted Streamable HTTP endpoint to Developer Tools in alphabetical order. The entry uses the existing [Glama connector](https://glama.ai/mcp/connectors/ai.prompeteer/prompeteer), whose page and score badge both return HTTP 200. The description is 102 characters to respect the contribution limit.

- [x] The endpoint is public and answers an MCP `initialize` request with HTTP 401 and OAuth discovery in `WWW-Authenticate`, the authenticated-server response accepted by this repository's check.
- [x] Entry is in the correct category, in alphabetical order.
- [x] Entry has its Glama connector badge on the second line.
- [x] Auth marker matches what the endpoint actually does.

Validation on 10 September 2026: anonymous initialize returned HTTP 401; protected-resource and authorization-server metadata returned HTTP 200 with authorization-code, refresh-token, and S256 PKCE metadata. No authenticated tool call or generation was performed. Glama currently marks the connector Unhealthy, so this PR does not claim a successful authenticated health test.
