### PR TITLE
Add Superflow Free Tools (remote MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Company logos, brand colors, and firmographic data by domain.
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
+- [Superflow Free Tools](https://usesuperflow.ai/tools) `https://usesuperflow.ai/api/mcp`
+  [![Superflow Free Tools MCP connector](https://glama.ai/mcp/connectors/ai.usesuperflow/tools/badges/score.svg)](https://glama.ai/mcp/connectors/ai.usesuperflow/tools)
+  🔓 - Free website QA and AI-visibility tools: AI crawlability, robots.txt vs AI crawlers, llms.txt, JSON-LD, social previews, screenshots, and more. No account, no API key.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 


### PR DESCRIPTION
## Summary
Adds [Superflow Free Tools](https://usesuperflow.ai/tools) as a remote Streamable HTTP MCP server (`https://usesuperflow.ai/api/mcp`).

- Auth: none (🔓)
- Glama: https://glama.ai/mcp/connectors/ai.usesuperflow/tools
- Smithery: https://smithery.ai/servers/usesuperflow/tools
- Official registry: `ai.usesuperflow/tools`

## Note for maintainers
A prior submission to `awesome-mcp-servers` (#12565 by `velt-sdk`) was closed because remote/hosted servers belong in this list. This PR follows that guidance. No duplicate open PR from `rakesh-superflow` / `velt-sdk` / `velt-js` on this repo.

## Test plan
- [ ] Endpoint answers MCP `initialize`
- [ ] Glama badge loads
- [ ] Entry alphabetized under Marketing
