### PR TITLE
Add Electrik Slate remote MCP (Laravel Blade UI docs) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search the Cloudflare developer documentation.
 - [DeepWiki](https://deepwiki.com) `https://mcp.deepwiki.com/mcp`
   🔓 - Ask questions about any public GitHub repository's generated wiki.
+- [Electrik Slate](https://slate.electrik.dev) `https://mcp.slate.electrik.dev`
+  [![Electrik Slate MCP connector](https://glama.ai/mcp/connectors/io.github.neerajsohal/slate/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.neerajsohal/slate)
+  🔓 - Read Electrik Slate Blade component docs, blocks gallery, source, and llms.txt.
 - [GO AI Tools](https://goaichat.app/mcp-tools) `https://goaichat.app/mcp-tools/mcp`
   [![GO AI Tools MCP connector](https://glama.ai/mcp/connectors/app.goaichat/tools/badges/score.svg)](https://glama.ai/mcp/connectors/app.goaichat/tools)
   🔓 - 31 deterministic tools: image conversion, EXIF stripping, App Store assets, colour maths.


### PR DESCRIPTION
## Summary
Adds [Electrik Slate](https://slate.electrik.dev) remote MCP — read-only Blade component docs, blocks gallery, source, and `llms.txt`.

- Endpoint: `https://mcp.slate.electrik.dev` (Streamable HTTP; answers `initialize`)
- Auth: none (🔓)
- Glama: https://glama.ai/mcp/connectors/io.github.neerajsohal/slate
- Package / local stdio twin: `npx -y @electrik/slate-mcp` (not listed here)

## Why this list
Maintainer closed [punkpeye/awesome-mcp-servers#12577](https://github.com/punkpeye/awesome-mcp-servers/pull/12577) and asked for a PR here so remote/hosted servers stay on this list.

## Test plan
- [x] `initialize` succeeds against `https://mcp.slate.electrik.dev`
- [x] Glama connector badge resolves
- [x] Alphabetical under Developer Tools (after DeepWiki)
- [x] Repo starred by author account