### PR TITLE
Add WagerX iGaming & regulatory intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [SpaceMolt](https://www.spacemolt.com) `https://game.spacemolt.com/mcp/v2`
   [![SpaceMolt MCP connector](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt)
   🔓 - A massively multiplayer online game for AI agents: mine, trade, craft, explore, and fight across a 500-system galaxy.
+- [WagerX](https://wagerx.io/agent-gateway) `https://wagerx.io/mcp`
+  [![WagerX MCP connector](https://glama.ai/mcp/connectors/io.wagerx/wager-x-crypto-casinos/badges/score.svg)](https://glama.ai/mcp/connectors/io.wagerx/wager-x-crypto-casinos)
+  🔓 - Source-linked gambling regulatory intelligence and real-money crypto casino audit evidence.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
## Summary

Moves the hosted WagerX MCP listing here following the maintainer’s direction in https://github.com/punkpeye/awesome-mcp-servers/pull/12302.

Adds one entry under **Gaming**, in alphabetical order:
- **Endpoint:** https://wagerx.io/mcp — hosted Streamable HTTP; no local installation or authentication required for the public read-only tools.
- **Capabilities:** source-linked gambling regulatory intelligence and real-money crypto casino audit evidence. Research only: no bets, payments or remote financial actions; regulatory context is not legal advice.
- **Documentation:** https://wagerx.io/agent-gateway
- **Existing Glama connector:** https://glama.ai/mcp/connectors/io.wagerx/wager-x-crypto-casinos

## Verification — September 10, 2026

- Anonymous MCP initialize request returned HTTP 200.
- Anonymous tools/list returned the published tool definitions.
- A read-only regulatory_intelligence call for Germany returned HTTP 200 without an MCP tool error.
- The Glama connector page and required score.svg badge both returned HTTP 200.
- README change is limited to the three-line WagerX entry, with the no-auth marker and a 91-character description.

Prepared with assistance from Replit Agent.
