### PR TITLE
Add Calibrd

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AI Applyd](https://aiapplyd.com/mcps) `https://mcp.aiapplyd.com/mcp`
   [![AI Applyd MCP connector](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd)
   🔓 - ATS resume scoring, per-role resume rewriting, cover letters, interview prep, job matching, and auto-apply that submits on the employer's own hiring system across 12 ATS platforms. Sign in with Google to run a tool.
+- [Calibrd](https://www.calibrd.com/agent) `https://www.calibrd.com/mcp`
+  [![Calibrd MCP connector](https://glama.ai/mcp/connectors/com.calibrd/agent/badges/score.svg)](https://glama.ai/mcp/connectors/com.calibrd/agent)
+  🔐 - Score your CV against a job posting, then get the questions that role will ask and where they'll push back.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.


### PR DESCRIPTION
Adds **Calibrd** to Workplace & Productivity, between AI Applyd and Fireflies.

```
- [Calibrd](https://www.calibrd.com/agent) `https://www.calibrd.com/mcp`
  [![Calibrd MCP connector](https://glama.ai/mcp/connectors/com.calibrd/agent/badges/score.svg)](https://glama.ai/mcp/connectors/com.calibrd/agent)
  🔐 - Score your CV against a job posting, then get the questions that role will ask and where they'll push back.
```

Interview prep without leaving the assistant: score a CV against a real job posting, get the questions that role is likely to ask, and see where an interviewer would push back.

Checklist against CONTRIBUTING:

- **Publicly reachable.** `https://www.calibrd.com/mcp` answers with an OAuth challenge and advertises its resource metadata at `/.well-known/oauth-protected-resource/mcp`. Anyone can sign up.
- **Remote, Streamable HTTP.** No local process, no per-user endpoint URL, no paywalled handshake.
- **Glama badge.** `com.calibrd/agent`, listed and resolving.
- **Auth marker.** 🔐 — OAuth via Clerk, including RFC 7591 dynamic client registration, so clients register themselves.
- **Description.** 111 characters, ends with a period.
- **Ordering.** Alphabetical, case-insensitive, within the category.
- Repo starred.

Originally opened on `awesome-mcp-servers` (#13869) and redirected here — thanks for the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfCHH655RvrWRa66oUFazw