### PR TITLE
Add China Sourcing Audit MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AMZ Vault](https://www.amz-vault.com) `https://www.amz-vault.com/mcp`
   [![AMZ Vault MCP connector](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault/badges/score.svg)](https://glama.ai/mcp/connectors/com.amz-vault/amz-vault)
   🔐 - Run an Amazon seller brand from chat: profit analytics, PPC, inventory forecasting, listings, staged approvals.
+- [China Sourcing Audit](https://lu7897859-tech.github.io/doors/sourcing-audit/) `https://x402-stable-door.lu7897859.workers.dev/mcp`
+  [![China Sourcing Audit MCP connector](https://glama.ai/mcp/connectors/io.github.lu7897859-tech/china-sourcing-audit/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.lu7897859-tech/china-sourcing-audit)
+  🔑 - Verify Chinese suppliers before paying: fake factories, badge fraud, hijacked payments.
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
 - [Sense2](https://sense2.com.au) `https://sense2.com.au/api/mcp`

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Run an Amazon seller brand from chat: profit analytics, PPC, inventory forecasting, listings, staged approvals.
 - [China Sourcing Audit](https://lu7897859-tech.github.io/doors/sourcing-audit/) `https://x402-stable-door.lu7897859.workers.dev/mcp`
   [![China Sourcing Audit MCP connector](https://glama.ai/mcp/connectors/io.github.lu7897859-tech/china-sourcing-audit/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.lu7897859-tech/china-sourcing-audit)
-  🔑 - Verify Chinese suppliers before paying: fake factories, badge fraud, hijacked payments.
+  🔓 - Verify Chinese suppliers before paying: fake factories, badge fraud, hijacked payments.
 - [Nexez](https://nexez.ai/agents) `https://nexez.app/mcp`
   🔓 - Search merchants, inspect offers, and validate checkout or negotiation before buying.
 - [Sense2](https://sense2.com.au) `https://sense2.com.au/api/mcp`


### PR DESCRIPTION
Adds **China Sourcing Audit** to the E-Commerce category.

- Homepage: https://lu7897859-tech.github.io/doors/sourcing-audit/
- Endpoint: `https://x402-stable-door.lu7897859.workers.dev/mcp` (Streamable HTTP)
- Glama connector: https://glama.ai/mcp/connectors/io.github.lu7897859-tech/china-sourcing-audit
- Official registry: `io.github.lu7897859-tech/china-sourcing-audit`

One sentence: verifies Chinese suppliers before payment — fake factories, Gold Supplier badge fraud, hijacked payment accounts, capital-withdrawal and hiring-collapse signals — with real evidence chains (SAMR/GSXT registration, court filings).

MCP `initialize` handshake is public and keyless (50 free calls, then x402 per-call). Led by an automated agent (listed via the 🤖🤖🤖 opt-in).