### PR TITLE
Add Hundo to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   🔓 - Historical return data for funds and tickers.
+- [Hundo](https://hundo.finance/connect) `https://hundo.finance/mcp`
+  [![Hundo MCP connector](https://glama.ai/mcp/connectors/finance.hundo/hundo/badges/score.svg)](https://glama.ai/mcp/connectors/finance.hundo/hundo)
+  🔐 - Your own ledger in your AI: net worth, accounts, budgets, holdings and IOUs, plus transactions and budgets your agent drafts and you confirm before anything is written; tools need a paid plan.
 - [Kristo Intelligence](https://kristo-intelligence-api.onrender.com) `https://kristo-intelligence-api.onrender.com/mcp`
   🔓 - DeFi trading signals and market intelligence for agents on Base; x402 pay-per-call in USDC, no signup.
 - [Kyrodata](https://kyrodata.com) `https://mcp.kyrodata.com/mcp`


### PR DESCRIPTION
Adds [Hundo](https://hundo.finance/connect) to **Finance**.

```
- [Hundo](https://hundo.finance/connect) `https://hundo.finance/mcp`
  [![Hundo MCP connector](https://glama.ai/mcp/connectors/finance.hundo/hundo/badges/score.svg)](https://glama.ai/mcp/connectors/finance.hundo/hundo)
  🔐 - Your own ledger in your AI: net worth, accounts, budgets, holdings and IOUs, plus transactions and budgets your agent drafts and you confirm before anything is written; tools need a paid plan.
```

Hundo is a personal finance tracker with no bank connection — entries are typed, photographed, emailed in or drafted by your agent — so it works in any country. The MCP server exposes 11 read tools, 9 that only draft a proposal, and one `confirm_proposal` that is the only thing which writes. A proposal expires if it is never confirmed.

## Checklist

- **Public URL, answers `initialize`** — returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://hundo.finance/api/auth/.well-known/oauth-protected-resource"`. I ran your `probe()` from `check-submission.yml` verbatim against it: `{"ok":true,"auth":"🔐","status":401}`.
- **Usable by anyone** — public sign-up, no invite, no per-user endpoint URL. The endpoint is the same for everyone.
- **Streamable HTTP** — OAuth 2.1, no local process.
- **Glama connector** — [`finance.hundo/hundo`](https://glama.ai/mcp/connectors/finance.hundo/hundo), badge resolves `200 image/svg+xml`.
- **Alphabetical** — placed between Fruit Stand and Kristo Intelligence.

## One thing to flag

The tools require a paid plan, so I wrote that into the description rather than leaving it to be discovered. The tracker itself is free and unlimited; the MCP server is the paid part. If that puts it outside what you want in the list, say so and I will close this — I would rather not waste your time.

Published in the official MCP Registry as `finance.hundo/hundo`.