### PR TITLE
Add RunVouch to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Manage Rootly incidents, alerts, and on-call schedules.
 - [RunVouch](https://runvouch.com) `https://api.runvouch.com/mcp`
   [![RunVouch MCP connector](https://glama.ai/mcp/connectors/com.runvouch/runvouch/badges/score.svg)](https://glama.ai/mcp/connectors/com.runvouch/runvouch)
-  🔑 - Ask why last night's unattended run is missing, stalled, failed or unproven, check the cost caps, and read the tamper-evident proof of a finished run.
+  🔓 - Ask why last night's unattended run is missing, stalled, failed or unproven, check the cost caps, and read the tamper-evident proof of a finished run. Discovery is open so the connector can score it; tool calls need a free X-API-Key.
 - [Sentry](https://sentry.io) `https://mcp.sentry.dev/mcp`
   [![Sentry MCP connector](https://glama.ai/mcp/connectors/dev.sentry.mcp/sentry/badges/score.svg)](https://glama.ai/mcp/connectors/dev.sentry.mcp/sentry)
   🔐 - Investigate Sentry issues, events, and releases, and run Seer root-cause analysis.

--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Query your own MCP server's tool calls, first-call success, retries, empty results, and schema cost.
 - [Rootly](https://rootly.com) `https://mcp.rootly.com/mcp`
   🔐 - Manage Rootly incidents, alerts, and on-call schedules.
+- [RunVouch](https://runvouch.com) `https://api.runvouch.com/mcp`
+  [![RunVouch MCP connector](https://glama.ai/mcp/connectors/com.runvouch/runvouch/badges/score.svg)](https://glama.ai/mcp/connectors/com.runvouch/runvouch)
+  🔑 - Ask why last night's unattended run is missing, stalled, failed or unproven, check the cost caps, and read the tamper-evident proof of a finished run.
 - [Sentry](https://sentry.io) `https://mcp.sentry.dev/mcp`
   [![Sentry MCP connector](https://glama.ai/mcp/connectors/dev.sentry.mcp/sentry/badges/score.svg)](https://glama.ai/mcp/connectors/dev.sentry.mcp/sentry)
   🔐 - Investigate Sentry issues, events, and releases, and run Seer root-cause analysis.


### PR DESCRIPTION
RunVouch is a watchdog for unattended AI agents: it alerts when a scheduled run is missing,
stalled, failed, over its cost cap or finished without evidence that the work was done.

The MCP server is remote (`https://api.runvouch.com/mcp`, free key at runvouch.com) and exposes
status, alerts, runs and the proof of a finished run, so one agent can check on another before
it builds on last night's output.

Source: https://github.com/runvouch/runvouch (MIT, self-hostable)
Docs: https://runvouch.com/docs/mcp
Official MCP registry: com.runvouch/runvouch
