### PR TITLE
Add PostNext 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [PostLake](https://postlake.dev) `https://api.postlake.dev/mcp`
   [![PostLake MCP connector](https://glama.ai/mcp/connectors/dev.postlake/social/badges/score.svg)](https://glama.ai/mcp/connectors/dev.postlake/social)
   🔐 - Publish, schedule, and read analytics across X, LinkedIn, Instagram, TikTok, Facebook, Threads, Bluesky, YouTube, and Pinterest from one hosted MCP server.
+- [PostNext](https://postnext.io/mcp) `https://mcp.postnext.io/api`
+  [![PostNext MCP connector](https://glama.ai/mcp/connectors/io.postnext/postnext/badges/score.svg)](https://glama.ai/mcp/connectors/io.postnext/postnext)
+  🔐 - Draft, schedule and publish to X, Instagram, LinkedIn, TikTok, YouTube, Threads and Bluesky, plus channel analytics.
 - [SocialBu](https://socialbu.com/mcp-server) `https://socialbu.com/mcp`
   [![SocialBu MCP connector](https://glama.ai/mcp/connectors/io.github.usamaejaz/socialbu-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.usamaejaz/socialbu-mcp)
   🔐 - Create, schedule, publish, and analyze social media content; manage accounts, teams, and automations.


### PR DESCRIPTION
Adds PostNext to Social Media.

**What it is:** a hosted social publishing server. Tools cover drafting, scheduling and publishing to X, Instagram, LinkedIn, TikTok, YouTube, Threads and Bluesky, plus publish status, per-channel analytics, media upload and link-in-bio pages.

**Endpoint:** `https://mcp.postnext.io/api` — Streamable HTTP, OAuth 2.0 with dynamic client registration, so 🔐. Public sign-up with a free tier at https://postnext.io.

**Checklist against CONTRIBUTING:**

- Reachable at a public URL: yes. An unauthenticated `initialize` returns a JSON-RPC error envelope with HTTP 401, the same as the other OAuth entries in this section (Post Bridge, SocialBu, PostLake all return 401 unauthenticated).
- Usable by anyone: yes, public sign-up, not invite-only, not single-tenant.
- Streamable HTTP: yes. No local process involved.
- Glama connector badge: `io.postnext/postnext`, from the official MCP registry entry of the same name. The connector page and the badge SVG both resolve.
- Ordering: placed between PostLake and SocialBu, case-insensitive alphabetical.
- Description: 116 characters.
- Repository starred by this account.

Happy to adjust the wording or placement if anything disagrees with CI.