### PR TITLE
Add Termalin to Developer Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Razi Tools](https://www.razi.pro/developer) `https://www.razi.pro/api/mcp`
   [![Razi Tools MCP connector](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.razikallayi/razi-tools)
   🔓 - 28 file and text tools: merge, split and compress PDFs, OCR, image compression, SQL, QR codes, JWTs and mock data.
+- [Termalin](https://termal.in) `https://termal.in/mcp`
+  [![Termalin MCP connector](https://glama.ai/mcp/connectors/in.termal/termalin-web/badges/score.svg)](https://glama.ai/mcp/connectors/in.termal/termalin-web)
+  🔐 - Run commands and read or write files over SSH/SFTP on your enrolled servers, reached keylessly through Connectors.
 - [UI Verify](https://uiverify.ai) `https://uiverify.ai/api/mcp`
   [![UI Verify MCP connector](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify/badges/score.svg)](https://glama.ai/mcp/connectors/ai.uiverify/ui-verify)
   🔓 - Audit a web page for accessibility and layout issues.


### PR DESCRIPTION
Adds **Termalin** to Developer Tools.

Termalin is a cross-platform SSH client whose hosted MCP endpoint lets agents run commands and read/write files over SSH/SFTP on the user's own servers. Servers connect outward through Termalin Connectors (a one-line install), each call is authenticated with a short-lived certificate — no SSH keys are pasted anywhere — and every action is audited, with per-connection policy (full / allowlist / read-only).

- Endpoint: `https://termal.in/mcp` — Streamable HTTP, OAuth 2.1 with dynamic client registration + PKCE (🔐).
- Glama connector: [in.termal/termalin-web](https://glama.ai/mcp/connectors/in.termal/termalin-web) (badge included), also in the official MCP Registry under the same id.
- Public sign-up at https://termal.in.

Follow-up to punkpeye/awesome-mcp-servers#11631, which was closed with a note to resubmit hosted servers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rhnc7RRVDGVfNB3osGPyAJ