### PR TITLE
Add Deoochform to Workplace & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AI Applyd](https://aiapplyd.com/mcps) `https://mcp.aiapplyd.com/mcp`
   [![AI Applyd MCP connector](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.whateverneveranywhere/aiapplyd)
   🔓 - ATS resume scoring, per-role resume rewriting, cover letters, interview prep, job matching, and auto-apply that submits on the employer's own hiring system across 12 ATS platforms. Sign in with Google to run a tool.
+- [Deoochform](https://deoochform.com) `https://deoochform.com/api/mcp/v2`
+  [![Deoochform MCP connector](https://glama.ai/mcp/connectors/io.github.musaib001/deooch-forms/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.musaib001/deooch-forms)
+  🔐 - Create forms, read submissions, and build invitations. Respondents answer a public link without an account.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.


### PR DESCRIPTION
**Server:** Deoochform
**Endpoint:** `https://deoochform.com/api/mcp/v2`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Deoochform is a form builder with the MCP server as the point rather than an add-on. Describe a form, get a public link back, and read the responses in the same conversation. Respondents never sign in.

Ten tools: forms (`list_templates`, `create_form`, `update_form`, `get_form`, `list_forms`), responses (`list_submissions`, `get_submission`), invitations (`list_invitation_templates`, `create_invitation`, `publish_invitation`). No delete tool and no billing access.

On the first box: the endpoint is OAuth protected, so an unauthenticated `initialize` returns 401 with `WWW-Authenticate: Bearer resource_metadata=...` pointing at `/.well-known/oauth-protected-resource/api/mcp/v2`, which is the spec behaviour for a 🔐 server. It completes normally once authorized.

The listed URL is a payment-free variant, so nothing built through it can take money.

Registry: `io.github.musaib001/deooch-forms` · Repo: https://github.com/musaib001/deoochform-mcp
