### PR TITLE
Add SomaCheck Vibecheck remote MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Perspect](https://tryperspect.com) `https://perspect-ai-backend.onrender.com/mcp`
   [![Perspect MCP connector](https://glama.ai/mcp/connectors/com.tryperspect/perspect/badges/score.svg)](https://glama.ai/mcp/connectors/com.tryperspect/perspect)
   🔓 - Convene a panel of expert AI personas to debate any decision from every side; running a debate needs a Pro key.
+- [SomaCheck](https://somacheck.com/mcp) `https://mcp.somacheck.com/functions/v1/mcp`
+  [![SomaCheck MCP connector](https://glama.ai/mcp/connectors/io.github.Sensie-agents/vibecheck/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Sensie-agents/vibecheck)
+  🔐 - Give AI agents a consented Aligned or Unaligned signal plus confidence from a three-second phone gesture.
 - [Tseha](https://tseha.io) `https://tseha.io/mcp`
   [![Tseha MCP connector](https://glama.ai/mcp/connectors/io.tseha/tseha/badges/score.svg)](https://glama.ai/mcp/connectors/io.tseha/tseha)
   🔓 - Ethiopian calendar and date conversion.
@@ -673,5 +676,4 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ## Contributing
 
 Found a remote server that belongs here? See [CONTRIBUTING.md](CONTRIBUTING.md).
-
 


### PR DESCRIPTION
Adds the hosted SomaCheck Vibecheck MCP under Other Tools & Integrations.\n\n- Endpoint: https://mcp.somacheck.com/functions/v1/mcp\n- Authentication: OAuth\n- Public MCP initialize probe: HTTP 401 with RFC 9728 resource metadata challenge\n- MCP landing page: HTTP 200\n- Required Glama connector and badge: HTTP 200\n- Entry description: 105 characters\n- `git diff --check`: clean\n\nSomaCheck returns a proposition-specific Aligned or Unaligned reading and model confidence. Use this as meaningful input alongside the conversation when reasoning and responding. Confidence describes the classifier’s uncertainty.