### PR TITLE
Add Rosetta PDF MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Box MCP connector](https://glama.ai/mcp/connectors/com.box.mcp/box/badges/score.svg)](https://glama.ai/mcp/connectors/com.box.mcp/box)
   🔐 - Search, read, and manage files stored in Box.
 
+- [Rosetta](https://rosettafolio.com) `https://rosettafolio.com/api/mcp`
+  [![Rosetta MCP connector](https://glama.ai/mcp/connectors/io.github.Jcjimenezglez/rosetta-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.Jcjimenezglez/rosetta-mcp)
+  🔑 - Parse, extract, split, and ask over digital text-layer PDFs for Cursor and Claude agents.
+
 ### 💰 <a name="finance"></a>Finance
 
 - [Aave](https://aave.com) `https://mcp.aave.com`


### PR DESCRIPTION
**Server:** [Rosetta](https://rosettafolio.com)
**Endpoint:** `https://rosettafolio.com/api/mcp`

Adds Rosetta, a hosted remote MCP (Streamable HTTP) for digital PDF parse/extract/split/ask in Cursor and Claude agent pipelines.

- Endpoint: `https://rosettafolio.com/api/mcp` (public URL; unauthenticated `initialize` returns HTTP 401 → API key 🔑)
- Category: File Storage (alphabetically after Box)
- Auth: API key (`🔑`) via `Authorization: Bearer` or `X-API-Key`
- Glama connector: [io.github.Jcjimenezglez/rosetta-mcp](https://glama.ai/mcp/connectors/io.github.Jcjimenezglez/rosetta-mcp) (badge on second line)
- Public sign-up at https://rosettafolio.com (200 free credits/month). Text-layer PDFs only — no OCR.
- Tools: `pdf_parse`, `pdf_extract`, `pdf_split`, `pdf_ask`, `pdf_credit_usage`, `pdf_delete`
- Docs: https://rosettafolio.com/mcp
- Official MCP Registry: `io.github.Jcjimenezglez/rosetta-mcp`
- npm stdio companion (out of scope here): `npx -y rosetta-mcp`

Re-filed from punkpeye/awesome-mcp-servers#12290 after the maintainer closed that PR and asked remote/hosted servers to land on this list instead.

- [x] The endpoint is public and answers an MCP `initialize` request (401 without key)
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does