### PR TITLE
Add file2markdown (Search & Data Extraction) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Exa](https://exa.ai) `https://mcp.exa.ai/mcp`
   [![Exa MCP connector](https://glama.ai/mcp/connectors/ai.exa/exa/badges/score.svg)](https://glama.ai/mcp/connectors/ai.exa/exa)
   🔓 - Neural web search that returns full page contents.
+- [file2markdown](https://www.file2markdown.ai) `https://mcp.file2markdown.ai/mcp`
+  [![file2markdown MCP connector](https://glama.ai/mcp/connectors/ai.file2markdown/file2markdown/badges/score.svg)](https://glama.ai/mcp/connectors/ai.file2markdown/file2markdown)
+  🔓 - Convert PDFs, Office files and web pages to clean Markdown by URL or base64; 5 free a day, Pro key for more.
 - [Firecrawl](https://firecrawl.dev) `https://mcp.firecrawl.dev/v2/mcp`
   [![Firecrawl MCP connector](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.firecrawl.mcp/firecrawl-mcp)
   🔓 - Crawl, scrape, and extract structured data from websites.


### PR DESCRIPTION
Adds **file2markdown** to Search & Data Extraction (alphabetical, between Exa and Firecrawl).

- Endpoint: `https://mcp.file2markdown.ai/mcp` (Streamable HTTP; answers `initialize` and `tools/list` anonymously)
- Tools: `convert_url` (PDF, DOCX, PPTX, XLSX, HTML, EPUB or web page by URL → Markdown), `convert_base64`, `list_supported_formats`, `usage_status`
- Auth: none required (🔓); 5 conversions/day per IP without a key, a Pro API key removes the limit and enables OCR
- Glama connector: https://glama.ai/mcp/connectors/ai.file2markdown/file2markdown (claimed, scored, badge resolves)
- Homepage / setup guide: https://www.file2markdown.ai/mcp

This replaces punkpeye/awesome-mcp-servers#13224, which was closed when hosted servers moved to this list. I maintain the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)