### PR TITLE
Add Korea Nationwide Data and Korea Ocean Leisure 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GridHub](https://grid-hub.app/developers) `https://api.grid-hub.app/mcp`
   [![GridHub MCP connector](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jalcodev/gridhub)
   🔓 - Live and historical electricity prices and demand for 25 grid zones (US, EU, GB, AU); free sample mode, key, or x402.
+- [Korea Ocean Leisure](https://korea-ocean-mcp.picks-site.workers.dev/) `https://korea-ocean-mcp.picks-site.workers.dev/mcp`
+  [![Korea Ocean Leisure MCP connector](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-ocean-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-ocean-mcp)
+  🔓 - Korean tide times for 42 stations plus fishing, mudflat, beach, surf and scuba forecasts.
 
 ### 📂 <a name="file-storage"></a>File Storage
 
@@ -608,6 +611,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [FrontDesko](https://frontdesko.app) `https://mcp.frontdesko.app/mcp`
   [![FrontDesko MCP connector](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp)
   🔓 - Hotel PMS pricing and plan comparisons, OTA-commission savings math, docs search, and live demo-hotel availability.
+- [Korea Nationwide Data](https://korea-data-mcp.picks-site.workers.dev/) `https://korea-data-mcp.picks-site.workers.dev/mcp`
+  [![Korea Nationwide Data MCP connector](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp)
+  🔓 - Korean tourist attractions in Korean and English, bus stops across 138 cities, and 30-year weather normals.
 
 - [Roamzy](https://roamzy.io) `https://roamzy.io/mcp`
   [![Roamzy MCP connector](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server)


### PR DESCRIPTION
Two free, no-auth remote MCP servers for Korean public data. Both are Streamable HTTP on Cloudflare Workers, open to anyone, no signup.

**Korea Nationwide Data** — Travel & Transportation
`https://korea-data-mcp.picks-site.workers.dev/mcp` · 6 tools
Tourist attractions in Korean and English (Korea Tourism Organization), bus stops across 138 cities, and 30-year weather normals (KMA). Useful when an agent needs to ground a Korea trip or logistics question in official data rather than guess.

**Korea Ocean Leisure** — Environment
`https://korea-ocean-mcp.picks-site.workers.dev/mcp` · 8 tools
Tide times for 42 KHOA stations plus fishing, mudflat, beach, surf, scuba and sea-parting forecasts.

Both are listed as Glama connectors (badges included, TDQS A), report **Healthy**, and answer the `initialize` handshake. Source: [korea-data-mcp](https://github.com/sean-park-funda/korea-data-mcp) / [korea-ocean-mcp](https://github.com/sean-park-funda/korea-ocean-mcp). Repo starred.

Placed alphabetically within each category.

🤖 This PR was opened by an automated agent, per CONTRIBUTING.