### PR TITLE
Add Phishunt and TweetFeed 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,10 +564,16 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔒 <a name="security"></a>Security
 
+- [Phishunt](https://phishunt.io) `https://mcp.phishunt.io/`
+  [![Phishunt MCP connector](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/phishunt/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/phishunt)
+  🔓 - Public phishing-domain feed: check a domain, search detections by brand, and pivot on campaigns and certs.
 - [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) `https://mcp.glc-rag.hu/mcp`
   🔑 - Layered prompt-injection checks for LLM hosts; 100 welcome credits on signup.
 - [Semgrep](https://semgrep.dev) `https://mcp.semgrep.ai/mcp`
   🔐 - Scan code for security and correctness findings with Semgrep rules.
+- [TweetFeed](https://tweetfeed.live) `https://mcp.tweetfeed.live/`
+  [![TweetFeed MCP connector](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/tweetfeed/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/tweetfeed)
+  🔓 - IOCs (URLs, domains, IPs, hashes) shared on X by the security community: lookups, tags, trends, campaigns.
 
 ### 📣 <a name="social-media"></a>Social Media
 


### PR DESCRIPTION
Two remote, no-auth, CC0 threat-intel servers under the Security category, both listed as Glama connectors (rated A):

- **Phishunt** — `https://mcp.phishunt.io/` (Streamable HTTP, 11 tools). Public phishing-domain feed: check a domain, search detections by brand, campaigns and cert/infra pivots. Homepage https://phishunt.io, docs https://phishunt.io/agents/.
- **TweetFeed** — `https://mcp.tweetfeed.live/` (Streamable HTTP, 13 tools). IOCs (URLs, domains, IPs, hashes) shared on X by the security community: lookups, tags, trends and campaigns. Homepage https://tweetfeed.live.

Both endpoints answer `initialize` and `tools/list` anonymously; no sign-up or key needed.