### PR TITLE
Add Theyond (Search & Data Extraction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Scrape websites and run saved extraction recipes.
 - [Tavily](https://tavily.com) `https://mcp.tavily.com/mcp`
   🔐 - Web search and content extraction built for agents.
+- [Theyond](https://theyond.com) `https://theyond.com/mcp`
+  [![Theyond MCP connector](https://glama.ai/mcp/connectors/com.theyond/theyond/badges/score.svg)](https://glama.ai/mcp/connectors/com.theyond/theyond)
+  🔓 - If it's here, it's on their board — live jobs from employer career pages, apply on theyond.com.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds Theyond, a public remote MCP for live jobs from employer career pages.

- Endpoint: `https://theyond.com/mcp` (streamable HTTP, no auth)
- Tools: `search_jobs`, `get_job`
- Results are theyond.com job pages so people apply on theyond
- Glama: https://glama.ai/mcp/connectors/com.theyond/theyond
- Docs: https://theyond.com/mcp

Handshake should answer `initialize` for CI.
