### PR TITLE
Add Corbelworks 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Extract web content and metadata, discover site resources, and detect page changes, with free discovery tools and pay-per-call x402 USDC operations on Base.
 - [Bright Data](https://brightdata.com) `https://mcp.brightdata.com/mcp`
   🔐 - Web scraping and SERP data through a managed proxy network.
+- [Corbelworks](https://corbelworks.pages.dev) `https://corbelworks.pages.dev/mcp`
+  [![Corbelworks MCP connector](https://glama.ai/mcp/connectors/dev.pages.corbelworks/reliability/badges/score.svg)](https://glama.ai/mcp/connectors/dev.pages.corbelworks/reliability)
+  🔓 - Runs a defect scan against a software vendor's public claims and returns structured findings with evidence grades and a buyer-intake tool.
 - [Cloudflare Radar](https://radar.cloudflare.com) `https://radar.mcp.cloudflare.com/mcp`
   🔐 - Internet traffic, routing, and security trends from Cloudflare Radar.
 - [Exa](https://exa.ai) `https://mcp.exa.ai/mcp`


### PR DESCRIPTION
Adds Corbelworks, a remote MCP server that runs structured defect scans against vendor claims and exposes a buyer-intake tool. Endpoint: https://corbelworks.pages.dev/mcp. Glama connector: https://glama.ai/mcp/connectors/dev.pages.corbelworks/reliability. No auth required.