### PR TITLE
Add Stoxly

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [StackEasy](https://www.stackeasy.ai/mcp) `https://data.stackeasy.ai/mcp`
   [![StackEasy MCP connector](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards/badges/score.svg)](https://glama.ai/mcp/connectors/ai.stackeasy/credit-cards)
   🔐 - Your own credit cards in your AI: balances, utilization, best card for a purchase, and missed rewards, read only.
+- [Stoxly](https://www.stoxlyonline.com/mcp) `https://www.stoxlyonline.com/api/mcp`
+  [![Stoxly MCP connector](https://glama.ai/mcp/connectors/io.github.wizard-exe/stoxly/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.wizard-exe/stoxly)
+  🔓 - Free stock and ETF fundamental analysis: 10-criteria score, verdict, and key metrics for any ticker, no key needed.
 - [The Undesirables TCG Oracle](https://the-undesirables.com) `https://mcp.the-undesirables.com/mcp`
   [![The Undesirables TCG Oracle MCP connector](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sailorpepe/undesirables-mcp-server)
   🔓 - On-chain TCG price oracle: 456K+ cards, calibrated risk forecasts, AI grading, loan terms; free reads, x402 paid tools.


### PR DESCRIPTION
## What

Adds **[Stoxly](https://www.stoxlyonline.com/mcp)** to the **Finance** category (alphabetical, between StackEasy and The Undesirables TCG Oracle).

Follow-up to punkpeye/awesome-mcp-servers#11864, which was closed with a pointer to this list.

## About the server

- Remote Streamable HTTP endpoint: `https://www.stoxlyonline.com/api/mcp` — 🔓 no auth, no API key, publicly usable
- Two tools: `analyze_stock` and `analyze_etf` — each returns a 10-criteria fundamental score, a descriptive verdict, all underlying metrics and the canonical analysis page URL
- Rate limited to 30 tool calls per IP per hour
- Glama connector: https://glama.ai/mcp/connectors/io.github.wizard-exe/stoxly (healthy, tool definition quality A)

## Checklist

- [x] Repository starred
- [x] Name links to the product homepage, endpoint in backticks, Glama connector badge, auth marker + description ≤ 120 chars
- [x] Alphabetical within the category
- [x] Endpoint verified responding (handshake and tool calls work without credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)