### PR TITLE
Add Loadster

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Ionic Framework MCP Server by Capawesome](https://capawesome.io/docs/ai/mcp/ionic-framework/) `https://ionic-framework-mcp.capawesome.io/mcp`
   [![Ionic Framework MCP connector](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.capawesome/ionic-framework-mcp)
   🔓 - Unofficial: search the Ionic Framework docs for v8 and v9, with the component API and usage examples.
+- [Loadster](https://loadster.com/manual/ai-agents/) `https://api.loadster.com/mcp`
+  [![Loadster MCP connector](https://glama.ai/mcp/connectors/com.loadster/loadster-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.loadster/loadster-mcp)
+  🔐 - Run load tests and synthetic monitors with Playwright, Browser Bot, or Protocol Bot scripts, and analyze results.
 - [MemorySync Documentation](https://docs.memorysync.io/mcp/overview) `https://docs.memorysync.io/mcp`
   [![MemorySync Docs MCP connector](https://glama.ai/mcp/connectors/io.memorysync/docs/badges/score.svg)](https://glama.ai/mcp/connectors/io.memorysync/docs)
   🔓 - Search and read MemorySync's API, SDK, and integration documentation from an MCP-compatible coding assistant.


### PR DESCRIPTION
Loadster is a load testing and synthetic monitoring platform. The remote MCP server lets an agent author Playwright, Browser Bot, and Protocol Bot scripts, run them as load tests or scheduled monitors from a global bot network, and analyze results, traces, and incidents.

Added under Developer Tools, alphabetically between Ionic Framework and mumo.

- Endpoint: `https://api.loadster.com/mcp` (Streamable HTTP)
- Auth: 🔐 OAuth, with public sign-up and a free tier
- Glama connector: https://glama.ai/mcp/connectors/com.loadster/loadster-mcp (healthy, badge included)
- Also published to the official registry as `com.loadster/loadster-mcp`

Repo starred.