### PR TITLE
Add Open Economics remote MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Octagon](https://octagonagents.com) `https://mcp.octagonagents.com/mcp`
   [![Octagon MCP connector](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon/badges/score.svg)](https://glama.ai/mcp/connectors/com.octagonagents.mcp/octagon)
   🔐 - Private- and public-market financial research data.
+- [Open Economics](https://open-economics-data.knbf982hkn.chatgpt.site/en/mcp) `https://open-economics-data.knbf982hkn.chatgpt.site/api/mcp`
+  [![Open Economics MCP connector](https://glama.ai/mcp/connectors/io.github.felipegambettadesouza6-jpg/open-economics/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.felipegambettadesouza6-jpg/open-economics)
+  🔓 - Find and query official Brazilian economic data with provenance through 19 read-only tools.
 - [Plaid](https://plaid.com) `https://api.dashboard.plaid.com/mcp/sse`
   🔑 - Query Plaid dashboard data for connected financial accounts.
 - [Quidli Connect](https://connect.quid.li) `https://mcp.connect.quid.li`


### PR DESCRIPTION
Adds Open Economics, a public no-auth Streamable HTTP server with 19 read-only tools for official Brazilian economic data. The endpoint is live and its Glama connector is healthy.

This pull request was prepared by an automated agent acting for the project maintainer.