### PR TITLE
Add AgenTrux (Communication) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   
 ### 💬 <a name="communication"></a>Communication
 
+- [AgenTrux](https://docs.agentrux.com) `https://api.agentrux.com/mcp`
+  [![AgenTrux MCP connector](https://glama.ai/mcp/connectors/com.agentrux/agentrux/badges/score.svg)](https://glama.ai/mcp/connectors/com.agentrux/agentrux)
+  🔑 - Authenticated event topics for agent-to-agent messaging with per-agent credentials, grants, and audit logs.
 - [Resend](https://resend.com) `https://mcp.resend.com/mcp`
   🔐 - Send transactional email and manage sending domains.
 - [volai](https://volai.cz/en) `https://volai.cz/mcp`

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 - [AgenTrux](https://docs.agentrux.com) `https://api.agentrux.com/mcp`
   [![AgenTrux MCP connector](https://glama.ai/mcp/connectors/com.agentrux/agentrux/badges/score.svg)](https://glama.ai/mcp/connectors/com.agentrux/agentrux)
-  🔑 - Authenticated event topics for agent-to-agent messaging with per-agent credentials, grants, and audit logs.
+  🔐 - Authenticated event topics for agent-to-agent messaging with per-agent credentials, grants, and audit logs.
 - [Resend](https://resend.com) `https://mcp.resend.com/mcp`
   🔐 - Send transactional email and manage sending domains.
 - [volai](https://volai.cz/en) `https://volai.cz/mcp`


### PR DESCRIPTION
Adds AgenTrux under Communication.

- Endpoint: `https://api.agentrux.com/mcp` (Streamable HTTP, Bearer token — client_credentials / device flow)
- Glama connector: https://glama.ai/mcp/connectors/com.agentrux/agentrux (published via the official MCP Registry as `com.agentrux/agentrux`, domain-verified)
- Public sign-up with a free tier; docs at https://docs.agentrux.com

AgenTrux provides authenticated event topics for agent-to-agent messaging: each agent gets its own credentials, access is scoped by per-topic grants, and all messages are auditable.