### PR TITLE
Add Jet Tracker (Brazilian business aviation intelligence) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [FrontDesko](https://frontdesko.app) `https://mcp.frontdesko.app/mcp`
   [![FrontDesko MCP connector](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.anmols/frontdesko-mcp)
   🔓 - Hotel PMS pricing and plan comparisons, OTA-commission savings math, docs search, and live demo-hotel availability.
+- [Jet Tracker](https://jettracker.com.br/desenvolvedores) `https://jettracker.com.br/api/mcp`
+  [![Jet Tracker MCP connector](https://glama.ai/mcp/connectors/br.com.jettracker/jet-tracker/badges/score.svg)](https://glama.ai/mcp/connectors/br.com.jettracker/jet-tracker)
+  🔐 - Brazilian business aviation: each aircraft's real owner, flights, overnight base, market and maintenance signals.
 - [Korea Nationwide Data](https://korea-data-mcp.picks-site.workers.dev/) `https://korea-data-mcp.picks-site.workers.dev/mcp`
   [![Korea Nationwide Data MCP connector](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp)
   🔓 - Korean tourist attractions in Korean and English, bus stops across 138 cities, and 30-year weather normals.


### PR DESCRIPTION
Adds **Jet Tracker** to *Travel & Transportation*, alphabetically between FrontDesko and Korea Nationwide Data.

- **Endpoint:** `https://jettracker.com.br/api/mcp` (Streamable HTTP, stateless)
- **Auth:** 🔐 OAuth 2.1 with dynamic client registration and PKCE. Unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer ... resource_metadata="https://jettracker.com.br/.well-known/oauth-protected-resource/api/mcp"`, which is what the check expects for OAuth servers. Public sign-up.
- **Glama connector:** [br.com.jettracker/jet-tracker](https://glama.ai/mcp/connectors/br.com.jettracker/jet-tracker) (badge included). Also published in the official MCP Registry as `br.com.jettracker/jet-tracker` 0.7.0.
- **What it does:** 28 read-only tools over the official Brazilian aircraft registry (RAB/ANAC) cross-referenced with the real owner (Receita Federal company records), tracked flights, overnight base, airport traffic, market listings, operating cost and maintenance signals (CVA validity, stays at certified shops from the ANAC RBAC 145 list), with FAA and GAMA context.
- **Data discipline:** every number carries a source and an as-of date; personal tax IDs are never returned and there is no search by a person's name.
- **Docs:** https://jettracker.com.br/desenvolvedores

The homepage links to the public developer docs because the product is a hosted service and the endpoint is the thing being listed.