### PR TITLE
Add Briefing Service 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [1cent](https://1cent.maxzoa.ru) `https://1cent.maxzoa.ru/mcp`
   [![1cent MCP connector](https://glama.ai/mcp/connectors/ru.maxzoa/1cent/badges/score.svg)](https://glama.ai/mcp/connectors/ru.maxzoa/1cent)
   🔓 - Extract web content and metadata, discover site resources, and detect page changes, with free discovery tools and pay-per-call x402 USDC operations on Base.
+- [Briefing Service](https://briefing-service.wholemind.workers.dev) `https://briefing-service.wholemind.workers.dev/mcp`
+  [![Briefing Service MCP connector](https://glama.ai/mcp/connectors/io.github.jshelley/briefings/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.jshelley/briefings)
+  🔓 - Hourly LLM-ranked news briefings on AI, markets, sports, and world news as JSON and e-ink pages; paid tools via x402.
 - [Bright Data](https://brightdata.com) `https://mcp.brightdata.com/mcp`
   🔐 - Web scraping and SERP data through a managed proxy network.
 - [Cloudflare Radar](https://radar.cloudflare.com) `https://radar.mcp.cloudflare.com/mcp`


### PR DESCRIPTION
**Server:** Briefing Service
**Endpoint:** `https://briefing-service.wholemind.workers.dev/mcp`

Briefing Service publishes hourly LLM-ranked news briefings (AI, frontier labs, markets, US sports, European football, US and world news) as structured JSON plus rendered e-ink pages, over Streamable HTTP. Listing briefings and front pages is free with no auth; `get_briefing`, `get_page`, and `render_briefing` are paid per call via x402 (USDC on Base) or a monthly license key. It is also listed in the official MCP registry as `io.github.jshelley/briefings`.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTWEKMyJNH32fec1uMyESq
