### PR TITLE
Add CARMOTIF Automotive Design 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Canva](https://canva.com) `https://mcp.canva.com/mcp`
   [![Canva MCP connector](https://glama.ai/mcp/connectors/com.canva.mcp/canva/badges/score.svg)](https://glama.ai/mcp/connectors/com.canva.mcp/canva)
   🔐 - Create, edit, and export Canva designs.
+- [CARMOTIF](https://agent.carmotif.com/) `https://api.carmotif.com/mcp`
+  [![CARMOTIF MCP connector](https://glama.ai/mcp/connectors/io.github.xgone/carmotif-agent/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.xgone/carmotif-agent)
+  🔐 - Search automotive design references by brand, model, year, colour, parts, and natural language; API key required.
 - [Figma](https://figma.com) `https://mcp.figma.com/mcp`
   [![Figma MCP connector](https://glama.ai/mcp/connectors/com.figma.mcp/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.figma.mcp/mcp)
   🔐 - Read Figma files and turn frames and components into code.


### PR DESCRIPTION
## CARMOTIF Automotive Design

Adds CARMOTIF to **Art & Design**, alphabetically between Canva and Figma.

- Homepage: https://agent.carmotif.com/
- Endpoint: `https://api.carmotif.com/mcp` (Streamable HTTP)
- Glama connector: https://glama.ai/mcp/connectors/io.github.xgone/carmotif-agent
- Official MCP Registry: `io.github.xgone/carmotif-agent`
- Authentication: API key sent as `Authorization: Bearer <key>`; public signup is documented on the homepage.
- Tools cover structured and natural-language automotive design reference search, image retrieval, comparison, and facets.

## Checks

- Glama ownership is verified and the connector badge resolves with HTTP 200.
- The endpoint is publicly reachable and returns an MCP Bearer challenge when credentials are omitted; no API key is included in this PR.
- The endpoint response is classified by the repository's CI as the Bearer-token marker; the service uses an API key, not an OAuth browser flow, as stated in the entry description and this PR.
- Description is 113 characters and ends with a period.
- No secrets or tracking URLs are included.
