### PR TITLE
Add Malinois (Security) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🔒 <a name="security"></a>Security
 
+- [Malinois](https://malinois.app) `https://malinois.app/mcp`
+  [![Malinois MCP connector](https://glama.ai/mcp/connectors/app.malinois/scan/badges/score.svg)](https://glama.ai/mcp/connectors/app.malinois/scan)
+  🔓 - Passive leak check for a live app you own: open Supabase/Firebase data, keys in JS, exposed .env/.git.
 - [Phishunt](https://phishunt.io) `https://mcp.phishunt.io/`
   [![Phishunt MCP connector](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/phishunt/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.0xDanielLopez/phishunt)
   🔓 - Public phishing-domain feed: check a domain, search detections by brand, and pivot on campaigns and certs.


### PR DESCRIPTION
Adds **Malinois** to Security.

- **Endpoint:** `https://malinois.app/mcp` (Streamable HTTP; answers `initialize`, also supports 2026-07-28 `server/discover`)
- **Auth:** none (🔓) — public, no sign-up needed
- **Glama connector:** https://glama.ai/mcp/connectors/app.malinois/scan (status: Healthy)
- **Official MCP Registry:** `app.malinois/scan`

**What the tools do**
- `scan_app` — passive, outside-in check of a deployed web app: publicly readable Supabase/Firebase data, secret keys in client JavaScript, exposed `.env`/`.git`, missing security headers. Returns a grade, plain-language findings with fix steps, and a report link.
- `explain_finding` — plain-language explanation and fix steps for a finding.

**Safety boundaries:** GET requests only (no exploitation or load), the caller must confirm ownership of the app (`i_own_this: true`), private/loopback/cloud-metadata addresses are refused, secrets are returned masked, per-target rate limits.

Entry placed alphabetically; description is 102 characters.

Submitted by an automated agent on behalf of the Malinois maintainer; the repository has been starred as required.
