### PR TITLE
Add Oriora Router (Aggregators) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [nohumans.directory](https://nohumans.directory) `https://api.nohumans.directory/mcp`
   [![nohumans.directory MCP connector](https://glama.ai/mcp/connectors/directory.nohumans/registry/badges/score.svg)](https://glama.ai/mcp/connectors/directory.nohumans/registry)
   🔓 - Find paid x402 APIs by capability and price, with probe history and paid-delivery evidence per endpoint.
+- [Oriora Router](https://orioralabs.com/managed-api-byok) `https://api.orioralabs.com/mcp`
+  [![Oriora Router MCP connector](https://glama.ai/mcp/connectors/com.orioralabs/router/badges/score.svg)](https://glama.ai/mcp/connectors/com.orioralabs/router)
+  🔐 - Picks the best AI model for each prompt, or routes and runs it on your own vendor keys.
 - [TaskFuel](https://taskfuel.ai) `https://app.taskfuel.ai/mcp`
   [![TaskFuel MCP connector](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.taskfuel.app/task-fuelai)
   🔐 - Discover and call paid per-request APIs for web search, market data, and enrichment, billed to a prepaid balance.


### PR DESCRIPTION
**Server:** Oriora Router
**Endpoint:** https://api.orioralabs.com/mcp

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Resubmitted here as requested in punkpeye/awesome-mcp-servers#10087. I'm affiliated with the project (Oriora Labs OÜ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZaBoCEkhQCdtDioWtSRoh