### PR TITLE
Add Browser Forest (undetectable cloud browser sessions) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🌐 <a name="browser-automation"></a>Browser Automation
 
+- [Browser Forest](https://browserforest.com) `https://browserforest.com/api/mcp/bf`
+  [![Browser Forest MCP connector](https://glama.ai/mcp/connectors/com.browserforest/browser-forest/badges/score.svg)](https://glama.ai/mcp/connectors/com.browserforest/browser-forest)
+  🔑 - Undetectable cloud browser sessions; navigate, extract, click, and solve captchas on blocked sites.
+
 - [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/) `https://browser.mcp.cloudflare.com/mcp`
   🔐 - Render pages, capture screenshots, and scrape HTML from a URL.
 


### PR DESCRIPTION
Adds [Browser Forest](https://browserforest.com) to **Browser Automation**.

**What it is:** hosted anti-detect cloud browser sessions driven over CDP. The browser runs on our side with a kernel-patched Chromium, so agents and scrapers can navigate, extract, click, and solve captchas on sites that block automation.

**Checklist against CONTRIBUTING.md**
- Public URL that answers an MCP `initialize` request: `https://browserforest.com/api/mcp/bf` (Streamable HTTP)
- Usable by anyone: public self-serve sign-up, free tier (300 minutes / 30 days, no credit card)
- Speaks Streamable HTTP: yes
- Glama connector badge: `com.browserforest/browser-forest` (already live on Glama, previously claimed by us)
- Starred the repo
- Placed first in the section, `B` < `C` in "Cloudflare Browser Rendering", alphabetical

Note: the endpoint returns 401 without credentials — auth is an `X-API-Key` header, hence the 🔑 marker.

**Disclosure:** this PR was prepared by an automated agent operating on behalf of the project. Flagging per the CONTRIBUTING note.