### PR TITLE
Add ReadGZH WeChat article reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Parlel](https://parlel.com) `https://api.parlel.com/mcp`
   [![Parlel MCP connector](https://glama.ai/mcp/connectors/com.parlel.api/parlel/badges/score.svg)](https://glama.ai/mcp/connectors/com.parlel.api/parlel)
   🔓 - Search people, companies, and open roles on an open professional network. Free, no API key.
+- [ReadGZH](https://readgzh.site) `https://api.readgzh.site/mcp-server`
+  [![ReadGZH MCP connector](https://glama.ai/mcp/connectors/io.github.sweesama/readgzh/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sweesama/readgzh)
+  🔓 🔑 - Read public WeChat Official Account articles as Markdown and search previously cached articles.
 - [Realask](https://realask.net) `https://realask.net/mcp`
   [![Realask MCP connector](https://glama.ai/mcp/connectors/io.github.danelas/realask/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.danelas/realask)
   🔓 - Verify facts about US local businesses by phone — stock, all-in price, availability — as typed answers with evidence.


### PR DESCRIPTION
Adds ReadGZH under Search & Data Extraction. It is a hosted MCP service for reading public WeChat Official Account article URLs and searching its existing article cache.

- Public endpoint: https://api.readgzh.site/mcp-server
- Homepage and documentation: https://readgzh.site and https://readgzh.site/docs
- Existing Glama connector: https://glama.ai/mcp/connectors/io.github.sweesama/readgzh
- Authentication: anonymous access with a limited quota; optional API key for account quota. The separate OAuth endpoint is not the endpoint proposed in this entry.

Validation: an unauthenticated MCP initialize request returned HTTP 200 with server name `readgzh` and tools capability on 2026-09-11. No article extraction was invoked. The entry follows alphabetical order and includes the existing connector badge. Glama's indexed health status was stale; this submission does not claim a new Glama health check has passed.

I maintain ReadGZH. This contribution was prepared with AI assistance.
