### PR TITLE
Add Playgama to Gaming 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🎮 <a name="gaming"></a>Gaming
 
+- [Playgama](https://playgama.com/mcp/) `https://developer.playgama.com/api/mcp`
+  [![Playgama MCP connector](https://glama.ai/mcp/connectors/com.playgama.developer/playgama-developer-cabinet/badges/score.svg)](https://glama.ai/mcp/connectors/com.playgama.developer/playgama-developer-cabinet)
+  🔑 - Publish and manage HTML5 games on Playgama: game form, builds, covers, in-app catalog, sandbox link.
 - [SpaceMolt](https://www.spacemolt.com) `https://game.spacemolt.com/mcp/v2`
   [![SpaceMolt MCP connector](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.statico-alt/spacemolt)
   🔓 - A massively multiplayer online game for AI agents: mine, trade, craft, explore, and fight across a 500-system galaxy.


### PR DESCRIPTION
Adds the Playgama remote MCP server under **Gaming**.

**What it does.** Playgama hosts HTML5 games; this server puts the developer cabinet behind an MCP endpoint. An agent can create a game and fill in its form, upload a build and poll until the engine analysis finishes, upload covers in the exact sizes the form requires, edit the in-app catalog and leaderboards, get a QA Tool link, and publish a sandbox — a public link anyone can play. 20 tools, 10 of them read-only; submitting to moderation, deleting and payouts are deliberately not exposed.

**Checklist**

- Public URL, answers `initialize`: `https://developer.playgama.com/api/mcp` (Streamable HTTP, protocol `2025-06-18`).
- Open sign-up: any developer registers at developer.playgama.com and issues a free token at developer.playgama.com/mcp.
- Auth marker 🔑 — `Authorization: Bearer pgm_mcp_…`. The endpoint answers `401` without a token, so CI will see the handshake gated by an API key rather than OAuth.
- Glama connector listed and healthy: https://glama.ai/mcp/connectors/com.playgama.developer/playgama-developer-cabinet
- Alphabetical placement inside Gaming, one entry, description under 120 characters.
- Repository starred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
