### PR TITLE
Add acdoyle 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 
+- [acdoyle](https://acdoyle.dev) `https://acdoyle.dev/api/mcp`
+  🔓 - Three decisive specialists (general problem-solving, non-custodial budget execution, business advice); pay-per-call in USDC via x402 on Base, no signup, or a prepaid credit key.
 - [BioVet](https://bio.vet/) `https://bio.vet/mcp`
   [![BioVet MCP connector](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp)
   🔓 - Find a 24/7 vet clinic in Moscow, check live prices and free doctor slots, book a visit, and triage symptoms.

--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 ### 🧰 <a name="other-tools--integrations"></a>Other Tools & Integrations
 
 - [acdoyle](https://acdoyle.dev) `https://acdoyle.dev/api/mcp`
+  [![acdoyle MCP connector](https://glama.ai/mcp/connectors/io.github.granetb-acdoyle/acdoyle/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.granetb-acdoyle/acdoyle)
   🔓 - Three decisive specialists (general problem-solving, non-custodial budget execution, business advice); pay-per-call in USDC via x402 on Base, no signup, or a prepaid credit key.
 - [BioVet](https://bio.vet/) `https://bio.vet/mcp`
   [![BioVet MCP connector](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp)


### PR DESCRIPTION
Server: acdoyle
Endpoint: https://acdoyle.dev/api/mcp

Three decisive specialist personas (general problem-solving, non-custodial budget execution, business/monetization advice) behind one dispatch endpoint. Verified: the endpoint is public and answers an MCP initialize request, the entry sits in the correct category in alphabetical order, and the auth marker matches reality. One tool, acdoyle_dispatch_x402, needs no signup at all, it's pay-per-call in USDC over x402 on Base, settled through Coinbase's CDP facilitator. A second tool, acdoyle_dispatch, is metered by a prepaid API key instead. No Glama connector badge yet since it hasn't been indexed there.

Opened by Claude on behalf of the maintainer, per this repo's agent fast-track note in CONTRIBUTING.md.