### PR TITLE
Add ProofCore Notary to Security 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Public phishing-domain feed: check a domain, search detections by brand, and pivot on campaigns and certs.
 - [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) `https://mcp.glc-rag.hu/mcp`
   🔑 - Layered prompt-injection checks for LLM hosts; 100 welcome credits on signup.
+- [ProofCore](https://proofcore.org) `https://mcp.proofcore.org`
+  🔓 - Zero-auth cryptographic provenance and notarization engine anchoring AI outputs, audits, and agreements to TON Blockchain with strict zero-storage.
 - [Semgrep](https://semgrep.dev) `https://mcp.semgrep.ai/mcp`
   🔐 - Scan code for security and correctness findings with Semgrep rules.
 - [TweetFeed](https://tweetfeed.live) `https://mcp.tweetfeed.live/`

--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Promptguard](https://mcp.glc-rag.hu/guide/promptguard) `https://mcp.glc-rag.hu/mcp`
   🔑 - Layered prompt-injection checks for LLM hosts; 100 welcome credits on signup.
 - [ProofCore](https://proofcore.org) `https://mcp.proofcore.org`
+  [![ProofCore Notary MCP connector](https://glama.ai/mcp/connectors/org.proofcore.mcp/proof-core-notary/badges/score.svg)](https://glama.ai/mcp/connectors/org.proofcore.mcp/proof-core-notary)
   🔓 - Zero-auth cryptographic provenance and notarization engine anchoring AI outputs, audits, and agreements to TON Blockchain with strict zero-storage.
 - [Semgrep](https://semgrep.dev) `https://mcp.semgrep.ai/mcp`
   🔐 - Scan code for security and correctness findings with Semgrep rules.


### PR DESCRIPTION
Add ProofCore Notary (Zero-Auth, Zero-Storage cryptographic provenance on TON) as requested by maintainer in #12916.

<!--
Adding a remote MCP server? Keep the entry in this shape and delete the rest of this comment.

- [Name](https://homepage.example) `https://mcp.example.com/mcp`
  [![Name MCP connector](https://glama.ai/mcp/connectors/com.example/name/badges/score.svg)](https://glama.ai/mcp/connectors/com.example/name)
  🔐 - One sentence describing what the tools do.

Auth: 🔓 none · 🔑 API key · 🔐 OAuth
-->

**Server:**
**Endpoint:**

- [ ] The endpoint is public and answers an MCP `initialize` request
- [ ] Entry is in the correct category, in alphabetical order
- [ ] Entry has its Glama connector badge on the second line
- [ ] Auth marker matches what the endpoint actually does
