### PR TITLE
Add VoxOdds (Finance) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [skanfirmy](https://skanfirmy.pl) `https://skanfirmy.pl/mcp`
   [![skanfirmy MCP connector](https://glama.ai/mcp/connectors/io.github.bartosz-kuc/skanfirmy/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.bartosz-kuc/skanfirmy)
   🔓 - Verify Polish companies by NIP/KRS/REGON, the Ministry of Finance VAT white list (with bank-account match), and EU VAT via VIES — straight from official government registers, no key or signup.
+- [VoxOdds](https://voxodds.com) `https://voxodds.com/mcp`
+  [![VoxOdds MCP connector](https://glama.ai/mcp/connectors/com.voxodds/voxodds/badges/score.svg)](https://glama.ai/mcp/connectors/com.voxodds/voxodds)
+  🔓 - Live Polymarket and Kalshi odds, all-in executable quotes with fees, pre-bet EV checks, and audited AI track records.
 
 ### 🍽️ <a name="food--dining"></a>Food & Dining
 


### PR DESCRIPTION
Adds **VoxOdds** to Finance.

- Remote Streamable HTTP MCP server at `https://voxodds.com/mcp`, no auth (🔓). 18 read-mostly tools: live Polymarket/Kalshi odds, cross-venue compare, all-in executable quotes with order-book depth and venue fees, ranked opportunities, pre-bet EV/Kelly check, and an audited AI-vs-market forecast track record (agents can submit forecasts and get a public Brier scorecard).
- Glama connector: https://glama.ai/mcp/connectors/com.voxodds/voxodds (badge included). Official registry: `com.voxodds/voxodds` v1.8.0.
- Docs: https://github.com/softdevfz/voxodds-mcp · REST/OpenAPI: https://voxodds.com/api/openapi.json
- Verified today with `initialize`, `tools/list` and a `tools/call` on `get_market_odds`.

Alphabetical within Finance; account has starred the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1mooJKJedR9NHDPNAGFkq