### PR TITLE
Add CVR Lookup (Danish company register)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Company Check](https://api.foretak.dev) `https://api.foretak.dev/mcp`
   [![Company Check MCP connector](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp)
   🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.
+- [CVR Lookup](https://cvrlookup.dk/mcp) `https://cvrlookup.dk/api/mcp`
+  [![CVR Lookup MCP connector](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup/badges/score.svg)](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup)
+  🔓 - Danish company register: company lookup, name search, and annual-report financials; data tools need a free key.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   🔓 - Historical return data for funds and tickers.


### PR DESCRIPTION
**Server:** CVR Lookup
**Endpoint:** `https://cvrlookup.dk/api/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Remote MCP server for the Danish company register (CVR), sourced live from the official registry: look up any of 860,000+ active Danish companies by CVR number, search by name, and get parsed annual-report financials as structured JSON. Streamable HTTP, stateless.

The handshake and `tools/list` are open; `tools/call` takes a free API key as a Bearer token (1,000 calls/month, no card). Any `cvr_test_…` key (e.g. `cvr_test_demo`) returns fixtures, so the tools can be exercised end to end without signing up.

Follow-up to punkpeye/awesome-mcp-servers#11863, closed with the note that hosted servers now belong here.
