### PR TITLE
Add AdaptlyPost server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 📣 <a name="social-media"></a>Social Media
 
+- [AdaptlyPost](https://adaptlypost.com) `https://mcp.adaptlypost.com/mcp`
+  [![AdaptlyPost MCP connector](https://glama.ai/mcp/connectors/com.adaptlypost/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/com.adaptlypost/mcp-server)
+  🔐 - Schedule, publish and track posts on Instagram, TikTok, YouTube, X, Facebook, LinkedIn, Pinterest, Threads and Bluesky.
 - [AdminHub for Telegram](https://adminhub.tools/mcp/) `https://backend-git-production-cb93.up.railway.app/mcp`
   [![AdminHub for Telegram MCP connector](https://glama.ai/mcp/connectors/tools.adminhub/telegram/badges/score.svg)](https://glama.ai/mcp/connectors/tools.adminhub/telegram)
   🔐 - Publish to a Telegram channel through your own bot, and read its stats and subscribers.


### PR DESCRIPTION
**Server:** AdaptlyPost
**Endpoint:** `https://mcp.adaptlypost.com/mcp`

Hosted MCP server for AdaptlyPost. Tools create, schedule and publish posts on nine social networks, upload media, check per-platform results and read post analytics. Sign-in is OAuth; the endpoint answers unauthenticated requests with a 401 and a `resource_metadata` challenge. Social Media section.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does