### PR TITLE
Add Flowsery server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Check whether a third-party API is down, look up uptime history, or list recent outages across 294 independently-probed APIs (Stripe, OpenAI, AWS, GitHub, etc.).
 - [Cloudflare Observability](https://developers.cloudflare.com) `https://observability.mcp.cloudflare.com/mcp`
   🔐 - Query Workers logs, analytics, and error events.
+- [Flowsery](https://flowsery.com) `https://mcp.flowsery.com/mcp`
+  [![Flowsery MCP connector](https://glama.ai/mcp/connectors/com.flowsery/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/com.flowsery/mcp-server)
+  🔐 - Web analytics, revenue attribution, visitor profiles and the bugs AI found in session recordings of your sites.
 - [Grafana](https://grafana.com) `https://mcp.grafana.com/mcp`
   [![Grafana MCP connector](https://glama.ai/mcp/connectors/io.github.grafana/mcp-grafana/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.grafana/mcp-grafana)
   🔐 - Query Grafana dashboards, datasources, and alerts.


### PR DESCRIPTION
**Server:** Flowsery
**Endpoint:** `https://mcp.flowsery.com/mcp`

Hosted MCP server for Flowsery web analytics. Tools read traffic overviews, time series, breakdowns, real-time visitors, visitor profiles and the issues Flowsery's AI finds in session recordings. Sign-in is OAuth; the endpoint answers unauthenticated requests with a 401 and a `resource_metadata` challenge. Monitoring section.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does