### PR TITLE
Add RedReplier server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔑 - Company logos, brand colors, and firmographic data by domain.
 - [Mailcoach](https://mailcoach.app) `https://mcp.mailcoach.app`
   🔐 - Read subscribers, campaigns, stats and email logs; create drafts and templates, and send test emails.
+- [RedReplier](https://redreplier.com) `https://mcp.redreplier.com/mcp`
+  [![RedReplier MCP connector](https://glama.ai/mcp/connectors/com.redreplier/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/com.redreplier/mcp-server)
+  🔐 - Find Reddit, Hacker News, X and Bluesky posts that mention your product or keywords, scored for lead relevance.
 - [Superflow Free Tools](https://usesuperflow.ai/tools) `https://usesuperflow.ai/api/mcp`
   [![Superflow Free Tools MCP connector](https://glama.ai/mcp/connectors/ai.usesuperflow/tools/badges/score.svg)](https://glama.ai/mcp/connectors/ai.usesuperflow/tools)
   🔓 - Free website QA and AI-visibility tools: AI crawlability, robots.txt vs AI crawlers, llms.txt, JSON-LD, social previews, screenshots, and more. No account, no API key.


### PR DESCRIPTION
**Server:** RedReplier
**Endpoint:** `https://mcp.redreplier.com/mcp`

Hosted MCP server for RedReplier. Tools list monitored websites, read and triage keyword mentions from Reddit, Hacker News, X and Bluesky with AI relevance scores, and add keywords. Sign-in is OAuth; the endpoint answers unauthenticated requests with a 401 and a `resource_metadata` challenge. Marketing section.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does