### PR TITLE
Add Document Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Deoochform](https://deoochform.com) `https://deoochform.com/api/mcp/v2`
   [![Deoochform MCP connector](https://glama.ai/mcp/connectors/io.github.musaib001/deooch-forms/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.musaib001/deooch-forms)
   🔐 - Create forms, read submissions, and build invitations. Respondents answer a public link without an account.
+- [Document Player](https://documentplayer.com/connect-ai/) `https://documentplayer.com/mcp`
+  [![Document Player MCP connector](https://glama.ai/mcp/connectors/com.documentplayer/document-player/badges/score.svg)](https://glama.ai/mcp/connectors/com.documentplayer/document-player)
+  🔐 - Send text from your AI to a reader window to read along and listen, with playback controls for each sentence.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.


### PR DESCRIPTION
**Server:** [Document Player](https://documentplayer.com/connect-ai/)
**Endpoint:** `https://documentplayer.com/mcp`

Your AI can send text to Document Player to read aloud. The reader window shows the text and lets you control playback sentence by sentence.

Adds Document Player under Workplace & Productivity, with the setup guide, OAuth marker, and Glama connector badge.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Checks: Without sign-in, the endpoint returns HTTP 401 with a Bearer sign-in header and the resource metadata address, as accepted by this list's check. Glama's signed-in connection test passed and found `send_to_doc_player`. The setup guide, Glama listing, and badge all return HTTP 200.
