### PR TITLE
Add Coderbuds (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Search the Capawesome docs and blog; an API token adds the Capawesome Cloud management tools.
 - [Cloudflare Docs](https://developers.cloudflare.com) `https://docs.mcp.cloudflare.com/mcp`
   🔓 - Search the Cloudflare developer documentation.
+- [Coderbuds](https://coderbuds.com/docs/mcp?ref=awesome-remote-mcp) `https://coderbuds.com/mcp/insights`
+  [![Coderbuds MCP connector](https://glama.ai/mcp/connectors/com.coderbuds/insights/badges/score.svg)](https://glama.ai/mcp/connectors/com.coderbuds/insights)
+  🔐 - Read your team's delivery metrics, org map and shipping standards, and check a change against them before opening a PR.
 - [DeepWiki](https://deepwiki.com) `https://mcp.deepwiki.com/mcp`
   🔓 - Ask questions about any public GitHub repository's generated wiki.
 - [Electrik Slate](https://slate.electrik.dev) `https://mcp.slate.electrik.dev`


### PR DESCRIPTION
Adds Coderbuds under Developer Tools.

- **Endpoint:** `https://coderbuds.com/mcp/insights` — Streamable HTTP, OAuth 2.1 (DCR supported), public sign-up at coderbuds.com.
- **Glama connector:** https://glama.ai/mcp/connectors/com.coderbuds/insights
- **Official registry:** `com.coderbuds/insights` (domain-verified namespace)
- **Docs / install:** https://coderbuds.com/docs/mcp

Unauthenticated `initialize` returns `401` with `WWW-Authenticate: Bearer realm="mcp", resource_metadata=...`, so the 🔐 marker matches what the endpoint reports.