### PR TITLE
Add Mnemoverse to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [MarkIt](https://mark-it.co) `https://mark-it.co/api/mcp`
   [![MarkIt MCP connector](https://glama.ai/mcp/connectors/io.github.FuzulsFriend/markit/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.FuzulsFriend/markit)
   🔓 - Search, save, and set reminders in your personal library of saved links, posts, and notes. OAuth sign-in unlocks all tools.
+- [Mnemoverse](https://mnemoverse.com) `https://mcp.mnemoverse.com/mcp`
+  [![Mnemoverse MCP connector](https://glama.ai/mcp/connectors/io.github.mnemoverse/mcp-memory-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.mnemoverse/mcp-memory-server)
+  🔐 - Persistent agent memory over MCP; tell it a recalled memory helped or misled and it re-ranks the next recall.
 - [Notion](https://notion.com) `https://mcp.notion.com/mcp`
   🔐 - Read and write Notion pages, databases, and comments.
 - [notepad.page](https://notepad.page) `https://mcp.notepad.page/mcp`


### PR DESCRIPTION
Adds Mnemoverse to Knowledge & Memory, alphabetically between MarkIt and Notion.

Remote endpoint: `https://mcp.mnemoverse.com/mcp`, Streamable HTTP, OAuth (an unauthenticated `initialize` returns 401 with a `WWW-Authenticate: Bearer` header carrying `resource_metadata`, so the marker is 🔐). Public sign-up at console.mnemoverse.com; the same account is reached from Claude Code, Cursor, VS Code and ChatGPT.

What the tools do: persistent memory for agents with an outcome input. An agent saves durable decisions, recalls them before acting, and can report that a recalled memory helped or misled; later recall is re-ranked on that report.

Glama connector: https://glama.ai/mcp/connectors/io.github.mnemoverse/mcp-memory-server. The repository is starred from this account, as the guidelines ask. Disclosure: submitted by the project's team.