### PR TITLE
Add Connections under CRM 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Close](https://close.com) `https://mcp.close.com/mcp`
   [![Close MCP connector](https://glama.ai/mcp/connectors/com.close/close-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.close/close-mcp)
   🔐 - Read and update Close leads, contacts, and opportunities.
+- [Connections](https://studio.connections.icu/connect) `https://studio.connections.icu/v1/mcp`
+  [![Connections MCP connector](https://glama.ai/mcp/connectors/icu.connections/connections/badges/score.svg)](https://glama.ai/mcp/connectors/icu.connections/connections)
+  🔐 - Manage contacts, host and ticket events, post marketplace deals, and keep notes and memory.
 - [HubSpot](https://hubspot.com) `https://mcp.hubspot.com/anthropic`
   🔐 - Query and update HubSpot CRM contacts, companies, and deals.
 


### PR DESCRIPTION
Adds Connections to the CRM section: a hosted remote MCP server at `https://studio.connections.icu/v1/mcp`, streamable HTTP with OAuth 2.1 (PKCE, dynamic client registration), no local install. Entry is alphabetical and carries the Glama connector badge, which is verified.

This replaces our earlier entry in `punkpeye/awesome-mcp-servers` (PR #13886), which the maintainer closed on 2026-09-08 with a note to submit remote servers to this list instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)