### PR TITLE
Add FindEnergyRates (US electricity rates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Current conditions, a two-hour rain curve, and a rain-radar map drawn as text, readable without an image model.
 - [FindEnergyRates](https://findenergyrates.com) `https://findenergyrates.com/mcp`
   [![FindEnergyRates MCP connector](https://glama.ai/mcp/connectors/com.findenergyrates/electricity-rates/badges/score.svg)](https://glama.ai/mcp/connectors/com.findenergyrates/electricity-rates)
-  🔑 - Live US retail electricity plans by utility, price-to-compare rates, and ZIP-to-utility lookup; free key by email.
+  🔐 - Live US retail electricity plans by utility, price-to-compare rates, and ZIP-to-utility lookup; free key by email.
 - [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
   [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
   🔓 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [echorune](https://echorune.net) `https://echorune.net/mcp`
   [![echorune MCP connector](https://glama.ai/mcp/connectors/io.github.luoshu-echorune/echorune-radar/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.luoshu-echorune/echorune-radar)
   🔓 - Current conditions, a two-hour rain curve, and a rain-radar map drawn as text, readable without an image model.
+- [FindEnergyRates](https://findenergyrates.com) `https://findenergyrates.com/mcp`
+  [![FindEnergyRates MCP connector](https://glama.ai/mcp/connectors/com.findenergyrates/electricity-rates/badges/score.svg)](https://glama.ai/mcp/connectors/com.findenergyrates/electricity-rates)
+  🔑 - Live US retail electricity plans by utility, price-to-compare rates, and ZIP-to-utility lookup; free key by email.
 - [GreenCalculus](https://greencalculus.com/developers/) `https://mcp.greencalculus.com`
   [![GreenCalculus MCP connector](https://glama.ai/mcp/connectors/com.greencalculus/api/badges/score.svg)](https://glama.ai/mcp/connectors/com.greencalculus/api)
   🔓 - Sourced greenhouse-gas emission factors and audit-traced carbon calculations, every value citing its source cell.


### PR DESCRIPTION
Adds FindEnergyRates under Environment.

Remote Streamable HTTP server at `https://findenergyrates.com/mcp` exposing live US retail electricity data: `search_plans` (residential offers for one utility in one state, cheapest first), `get_ptc_rates` (utility price-to-compare / default-service rate), and `get_utility_by_zip` (ZIP → utility, including Texas TDSPs). Read-only.

Auth is an API key (`Authorization: Bearer <key>`), issued free by email to support@findenergyrates.com — anyone can request one, so this is a 🔑 entry, not 🔐. Note for the auth check: the endpoint answers anonymous `initialize` with `401` and `WWW-Authenticate: Bearer realm="fer-mcp"` — RFC 6750 bearer, no OAuth metadata, no `resource_metadata`. The probe's regex treats any `Bearer` challenge as OAuth, so it may label this 🔐; the marker is correct as 🔑.

Glama connector: https://glama.ai/mcp/connectors/com.findenergyrates/electricity-rates (ownership verified, healthy).
