### PR TITLE
Add GoodLeads (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [FoxForm](https://foxform.app) `https://mcp.foxform.app/mcp`
   [![FoxForm MCP connector](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form/badges/score.svg)](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form)
   🔓 - Build scored forms, quizzes and calculators, publish them, and read responses with per-screen analytics.
+- [GoodLeads](https://goodleads.club) `https://mcp.goodleads.club/mcp`
+  [![GoodLeads MCP connector](https://glama.ai/mcp/connectors/club.goodleads/new-business-owner-contacts/badges/score.svg)](https://glama.ai/mcp/connectors/club.goodleads/new-business-owner-contacts)
+  🔓 - Reach the owner of a newly formed business the morning after the state posts it, from the state's own filing.
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 - Audit a site's visibility in AI answer engines (AEO/GEO).


### PR DESCRIPTION
Adds **GoodLeads** to Marketing, alphabetical position.

- Homepage: https://goodleads.club
- Remote endpoint: `https://mcp.goodleads.club/mcp` (Streamable HTTP, keyless — 🔓)
- Glama connector: `club.goodleads/new-business-owner-contacts` (badge included)
- What it does: the owner of a newly formed US business — name, mailing address and, where verified, a phone or email — from the state's own filing, the morning after the state posts it. Browse, count and price free; pay per record for the file.

(A prior PR, #14149, was opened against awesome-mcp-servers by mistake — closed there per the bot's redirect since this is a remote-only server; this is the correct resubmission here.)

Agent-authored, human-reviewed (🤖🤖🤖 per CONTRIBUTING).