### PR TITLE
Add Candor Finance to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Autoview](https://autoview.com/) `https://api.autoview.com/mcp/`
   [![Autoview MCP connector](https://glama.ai/mcp/connectors/io.github.autoview-com/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.autoview-com/mcp)
   🔓 - Trade across 22+ exchanges and brokers from any MCP-capable AI agent; dry-run by default, live trading on Kraken and Crypto.com.
+- [Candor Finance](https://candor.money) `https://api.candor.money/mcp`
+  [![Candor Finance MCP connector](https://glama.ai/mcp/connectors/money.candor/candor-finance/badges/score.svg)](https://glama.ai/mcp/connectors/money.candor/candor-finance)
+  🔐 - Personal-finance workspace for AI agents: connected accounts, spending, budgets, goals, and investments.
 - [Company Check](https://api.foretak.dev) `https://api.foretak.dev/mcp`
   [![Company Check MCP connector](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp)
   🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.


### PR DESCRIPTION
**Server:** [Candor Finance](https://candor.money)
**Endpoint:** https://api.candor.money/mcp

Adds Candor Finance alphabetically under Finance. Candor is a hosted personal-finance workspace for AI agents with connected accounts, spending, budgets, goals, and investments. Public signup is available; access uses OAuth over Streamable HTTP.

- [x] The endpoint is public and answers an MCP `initialize` request with the OAuth challenge accepted by this repository's CI
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Validation: the unauthenticated CI-format initialize request returns HTTP 401 with `WWW-Authenticate: Bearer` and OAuth resource metadata. The Glama connector page and score badge both return HTTP 200. The description is under 120 characters and `git diff --check` passes.

This follows the maintainer's redirect from https://github.com/punkpeye/awesome-mcp-servers/pull/12285 when hosted servers moved to this list.
