### PR TITLE
Add Midpoint Card Prices (Finance) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [LitVM TCG Oracle](https://litvm.the-undesirables.com) `https://litvm.the-undesirables.com/mcp`
   [![LitVM TCG Oracle MCP connector](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle/badges/score.svg)](https://glama.ai/mcp/connectors/com.the-undesirables.litvm/lit-vm-tcg-oracle)
   🔓 - TCG price oracle for the LitecoinVM ecosystem: Merkle-proven prices, calibrated forecasts, fantasy souls; 13 free tools.
+- [Midpoint Card Prices](https://www.cardcenteringtool.com/mcp) `https://mcp.cardcenteringtool.com/mcp`
+  [![Midpoint Card Prices MCP connector](https://glama.ai/mcp/connectors/com.cardcenteringtool/card-prices/badges/score.svg)](https://glama.ai/mcp/connectors/com.cardcenteringtool/card-prices)
+  🔓 - Trading card prices and grading ROI for 1.5M+ Pokémon, TCG and sports cards: raw and PSA 9/10 values, movers.
 - [NuMetric](https://numetric.work) `https://numetric-mcp.virifi.xyz/mcp`
   [![NuMetric MCP connector](https://glama.ai/mcp/connectors/xyz.virifi.numetric-mcp/numetric/badges/score.svg)](https://glama.ai/mcp/connectors/xyz.virifi.numetric-mcp/numetric)
   🔐 - Read-only queries over NuMetric accounting and ERP books: financial statements, KPIs, receivables and payables, invoices, and documents.


### PR DESCRIPTION
Adds **Midpoint Card Prices** under Finance (alphabetical).

- Endpoint: `https://mcp.cardcenteringtool.com/mcp` (Streamable HTTP, 🔓 no auth, answers `initialize`)
- Glama connector: https://glama.ai/mcp/connectors/com.cardcenteringtool/card-prices (official registry `com.cardcenteringtool/card-prices`)
- Docs: https://www.cardcenteringtool.com/mcp · Source: https://github.com/kolourr/midpoint-mcp
- Nine read-only tools: search cards, full raw and graded ladder (PSA/CGC/BGS/SGC/TAG), grading ROI, price history, 30-day movers, liquid movers, best cards to grade, sets and checklists. 1.5M+ Pokémon, Magic, Yu-Gi-Oh!, One Piece, Lorcana, sports and entertainment cards.

Repo starred as required. Opened by an automated agent on behalf of the maintainer (hence the 🤖🤖🤖 opt-in).