### PR TITLE
Add dot•requirements (Project Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔐 - Work with Jira issues and Confluence pages.
 - [ClickUp](https://clickup.com) `https://mcp.clickup.com/mcp`
   🔐 - Manage ClickUp tasks, docs, and spaces.
+- [dot•requirements](https://dotrequirements.io) `https://app.dotrequirements.io/mcp`
+  [![dot•requirements MCP connector](https://glama.ai/mcp/connectors/io.dotrequirements/dotrequirements/badges/score.svg)](https://glama.ai/mcp/connectors/io.dotrequirements/dotrequirements)
+  🔐 - Draft testable requirements specs from chat, style-check them, publish to your team, and see test coverage.
 - [Linear](https://linear.app) `https://mcp.linear.app/mcp`
   [![Linear MCP connector](https://glama.ai/mcp/connectors/app.linear/linear/badges/score.svg)](https://glama.ai/mcp/connectors/app.linear/linear)
   🔐 - Manage Linear issues, projects, and cycles.


### PR DESCRIPTION
**Server:** dot•requirements — write product documentation to share with your whole team, including testable specifications. From chat you can draft a requirements spec, style-check it against the project's rubric, publish it for developers to sync into their repo, and ask which requirements are untested. Hosted by Popover AI Ltd; listed in the official MCP Registry as `io.dotrequirements/dotrequirements`.
**Endpoint:** `https://app.dotrequirements.io/mcp`

- [x] The endpoint is public and answers an MCP `initialize` request (401 with a `WWW-Authenticate: Bearer` challenge and RFC 9728 resource metadata)
- [x] Entry is in the correct category, in alphabetical order (Project Management, between ClickUp and Linear)
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does (🔐 OAuth via dynamic client registration)

This is the hosted successor to punkpeye/awesome-mcp-servers#12094, closed with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
