### PR TITLE
Add LocationLists (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Lekta](https://lekta.dev) `https://lekta.dev/mcp`
   [![Lekta MCP connector](https://glama.ai/mcp/connectors/dev.lekta/lektadev/badges/score.svg)](https://glama.ai/mcp/connectors/dev.lekta/lektadev)
   🔓 - Audit a site's visibility in AI answer engines (AEO/GEO).
+- [LocationLists](https://locationlists.com) `https://locationlists.com/mcp`
+  [![LocationLists MCP connector](https://glama.ai/mcp/connectors/io.github.kylehawke-stack/locationlists/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.kylehawke-stack/locationlists)
+  🔓 - Search 725 US business-location datasets (dealers, contractors, chains), preview real rows, and buy CSVs.
 - [LogoKit](https://logokit.com) `https://mcp.logokit.com/mcp`
   [![LogoKit MCP connector](https://glama.ai/mcp/connectors/com.logokit/brand-data/badges/score.svg)](https://glama.ai/mcp/connectors/com.logokit/brand-data)
   🔑 - Company logos, brand colors, and firmographic data by domain.


### PR DESCRIPTION
**Server:** [LocationLists](https://locationlists.com)
**Endpoint:** `https://locationlists.com/mcp`

Adds **LocationLists** under Marketing, alphabetically between Lekta and LogoKit.

LocationLists sells ready-to-use CSV datasets of US business locations — manufacturer dealer networks, licensed trade contractors by state, retail and restaurant chains — each compiled from the official locator, association directory or state license register that publishes it. The MCP tools let an agent search the 725-dataset catalog, read a dataset's full record, preview real rows, get a price quote, hand the user a Stripe checkout link, and confirm an order to fetch the download link. Tools: `search_datasets`, `get_dataset`, `get_sample`, `get_quote`, `create_checkout`, `check_order`, `query_locations`, `buy_dataset`.

- Transport: Streamable HTTP, stateless, JSON responses. Answers `initialize` anonymously with `serverInfo.name: LocationLists`, version 1.1.0, protocol 2025-06-18 — so the marker is 🔓.
- Glama connector: `io.github.kylehawke-stack/locationlists`. This is the server's name in the official MCP Registry (source: https://github.com/kylehawke-stack/locationlists-mcp, published in parallel with this PR). Glama connectors are keyed by the registry name, so the badge will resolve once Glama ingests the registry entry; if the connector check runs before that happens, I will re-trigger it.
- Privacy: https://locationlists.com/privacy · Terms: https://locationlists.com/license

Verify the handshake in one line:

```bash
curl -s -X POST https://locationlists.com/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
```

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

Repo starred as required. Opened by an automated agent on behalf of the maintainer (hence the 🤖🤖🤖 opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8d6SWbuBjmBsAPtkXUbJj
