### PR TITLE
Add TheQRCode.io to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Superflow Free Tools](https://usesuperflow.ai/tools) `https://usesuperflow.ai/api/mcp`
   [![Superflow Free Tools MCP connector](https://glama.ai/mcp/connectors/ai.usesuperflow/tools/badges/score.svg)](https://glama.ai/mcp/connectors/ai.usesuperflow/tools)
   🔓 - Free website QA and AI-visibility tools: AI crawlability, robots.txt vs AI crawlers, llms.txt, JSON-LD, social previews, screenshots, and more. No account, no API key.
+- [TheQRCode.io](https://theqrcode.io/mcp) `https://mcp.theqrcode.io/mcp`
+  [![TheQRCode.io MCP connector](https://glama.ai/mcp/connectors/io.theqrcode/qr-code-generator/badges/score.svg)](https://glama.ai/mcp/connectors/io.theqrcode/qr-code-generator)
+  🔓 - Generate QR codes, list saved codes, and read scan analytics by time, device and approximate location.
 - [Vibe Prospecting](https://vibeprospecting.ai) `https://vibeprospecting.explorium.ai/mcp`
   🔐 - Search companies and contacts, enrich lead lists, and research B2B business signals.
 


### PR DESCRIPTION
Adds **TheQRCode.io** — a remote MCP server for QR code generation and scan analytics — under Marketing.

### What it does

Three tools:

| Tool | Auth | |
|---|---|---|
| `generate_qr_code` | none | url, wifi, contact, text (+ email with a key). Returns a hosted PNG URL and a base64 data URL for inline display |
| `list_qr_codes` | API key | lists codes saved to the account, paginated, filterable by type |
| `get_analytics` | API key | scans by `1h`–`1y`: total and unique, time, device and OS, approximate location, campaign |

All three are advertised to anonymous sessions so `tools/list` shows the real surface; the two account tools refuse at call time without a key rather than hiding.

### Checklist

- **Reachable at a public URL** — `https://mcp.theqrcode.io/mcp` answers `initialize` (200, `theqrcode-mcp` 1.1.2, streamable HTTP).
- **Usable by anyone** — public sign-up, and `generate_qr_code` works anonymously with no key at 100 req/hr per IP.
- **Streamable HTTP** — yes, no local process.
- **Glama connector** — [`io.theqrcode/qr-code-generator`](https://glama.ai/mcp/connectors/io.theqrcode/qr-code-generator); badge resolves (200, `image/svg+xml`).
- **Marker** `🔓` — the endpoint takes no auth; the API key is optional and only adds the two account tools.
- Alphabetical within Marketing (after Superflow Free Tools, before Vibe Prospecting); description is 102 chars and ends in a period.
- Repo starred.

Also in the official MCP registry as `io.theqrcode/qr-code-generator`. Source: <https://github.com/awilliams-2020/theqrcode-mcp> (MIT).

Happy to adjust the marker or wording if CI reads it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdGYMtt7LPqTFoefbmMLg