### PR TITLE
Add Windsock — aircraft valuations, FAA registry, market data 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   🔓 - Buy and manage one global eSIM for 193 countries, billed per megabyte in USDT or USDC — no account, no signup, no KYC.
 - [Windsock](https://windsock.ai/mcp) `https://windsock.ai/mcp`
   [![Windsock MCP connector](https://glama.ai/mcp/connectors/ai.windsock/windsock/badges/score.svg)](https://glama.ai/mcp/connectors/ai.windsock/windsock)
-  🔐 - Aircraft valuations, FAA registry lookups, cost of ownership, comparable aircraft, ADs and STCs, market metrics, reports and logbooks.
+  🔐 - Aircraft valuations, FAA registry lookups, cost of ownership, ADs and STCs, market data, reports and logbooks.
 
 ### 🔄 <a name="version-control"></a>Version Control
 

--- a/README.md
+++ b/README.md
@@ -808,6 +808,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Roamzy](https://roamzy.io) `https://roamzy.io/mcp`
   [![Roamzy MCP connector](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server)
   🔓 - Buy and manage one global eSIM for 193 countries, billed per megabyte in USDT or USDC — no account, no signup, no KYC.
+- [Windsock](https://windsock.ai/mcp) `https://windsock.ai/mcp`
+  [![Windsock MCP connector](https://glama.ai/mcp/connectors/ai.windsock/windsock/badges/score.svg)](https://glama.ai/mcp/connectors/ai.windsock/windsock)
+  🔐 - Aircraft valuations, FAA registry lookups, cost of ownership, comparable aircraft, ADs and STCs, market metrics, reports and logbooks.
 
 ### 🔄 <a name="version-control"></a>Version Control
 


### PR DESCRIPTION
Adds **Windsock** under Travel & Transportation.

- Endpoint: `https://windsock.ai/mcp` (Streamable HTTP, protocol 2025-06-18; answers `initialize`)
- Auth: OAuth 2.1 with dynamic client registration (🔐); an account API key bearer is also accepted for headless agents
- Glama connector: https://glama.ai/mcp/connectors/ai.windsock/windsock (badge resolves)
- Official MCP Registry: `ai.windsock/windsock`
- Docs: https://windsock.ai/mcp — 38 tools: aircraft valuations, FAA registry lookups (US + 17 international registers), cost of ownership, comparable aircraft, fleet search, ADs and STCs, market metrics with forecasts, verified value reports, pre-buy diligence checklists, logbook search, watchlist.
- Public sign-up; free accounts get 20 of the 38 tools with a monthly call limit.

Opened by an automated agent on behalf of the Windsock team (team@windsock.ai).