### PR TITLE
Add CryptoMacro to Finance 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Company Check](https://api.foretak.dev) `https://api.foretak.dev/mcp`
   [![Company Check MCP connector](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.foretak/registry-mcp)
   🔓 - Look up a company at the UK's Companies House, Norway's Brønnøysundregistrene or Sweden's Bolagsverket, with what it has filed, plus UK charges and insolvency records.
+- [CryptoMacro](https://asistent-crypto.vercel.app/a2a) `https://asistent-crypto.vercel.app/mcp`
+  [![CryptoMacro MCP connector](https://glama.ai/mcp/connectors/io.github.dopionut-jpg/crypto-data-market-analysis/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.dopionut-jpg/crypto-data-market-analysis)
+  🔓 - Crypto positioning plus the macro regime: funding, open interest, order-book depth, implied volatility, Fed rates.
 - [CVR Lookup](https://cvrlookup.dk/mcp) `https://cvrlookup.dk/api/mcp`
   [![CVR Lookup MCP connector](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup/badges/score.svg)](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup)
   🔓 - Danish company register: company lookup, name search, and annual-report financials; data tools need a free key.


### PR DESCRIPTION
Adds **CryptoMacro** to the 💰 Finance category (alphabetically, between Company Check and CVR Lookup).

### What the server does

A remote MCP server that returns crypto market **positioning**, not just price — the signal set a trading desk watches, as structured JSON. 17 read-only tools:

- **Derivatives** — perpetual funding rate and open interest across Binance, Bybit, OKX and Hyperliquid, aggregated or broken down venue by venue. Thin venues are excluded: averaging every venue that publishes a rate overstates BTC funding by ~30x, because a near-empty book printing 9% per 8h counts the same as a deep one.
- **Execution** — live order-book depth walked at your notional, returning average fill price, slippage in bps and which venue is cheaper for that exact size.
- **Options** — 30-day implied volatility for BTC and ETH with percentile and expected move.
- **Macro regime** — the 2s10s curve spread, Fed funds, 2Y/10Y yields, CPI, dollar index, VIX and M2, plus the scheduled catalyst calendar (FOMC, CPI, PCE, NFP). This is the part most crypto MCP servers leave out.
- **Context** — sentiment, BTC/ETH/USDT dominance, DeFi TVL, large ETH exchange flows, Bitcoin network health, spot prices, and news headlines.
- **History** — the same series captured every ~10 minutes, so a reading comes back with its percentile rather than on its own.

Everything is fetched live per call; nothing is simulated, mocked or cached beyond short source-level TTLs.

### Checklist

- [x] Reachable at a public URL — `https://asistent-crypto.vercel.app/mcp` answers `initialize`
- [x] Usable by anyone — no account, no API key
- [x] Streamable HTTP (stateless)
- [x] Listed as a Glama connector — `io.github.dopionut-jpg/crypto-data-market-analysis`, badge included in the entry
- [x] Auth marker: 🔓
- [x] Alphabetical within the category
- [x] Description is one sentence, 114 characters
- [x] Repository starred

Also listed in the official MCP Registry as `io.github.dopionut-jpg/crypto-data-market-analysis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
