### PR TITLE
Add LetX to Content Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [GoodBarber](https://www.goodbarber.com/mcp/) `https://mcp.goodbarber.dev/mcp/sse`
   [![GoodBarber MCP connector](https://glama.ai/mcp/connectors/dev.goodbarber/goodbarber-public-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/dev.goodbarber/goodbarber-public-mcp)
   🔐 - Manage a GoodBarber no-code app: content, push notifications, shop orders, members, and analytics.
+- [LetX](https://letx.app/mcp/) `https://api.letx.app/mcp`
+  [![LetX MCP connector](https://glama.ai/mcp/connectors/app.letx/letx/badges/score.svg)](https://glama.ai/mcp/connectors/app.letx/letx)
+  🔐 - Write and compile LaTeX: search 1000+ journal, thesis and CV templates, create projects, edit files, and compile to PDF with the build log returned.
 - [Sanity](https://sanity.io) `https://mcp.sanity.io/mcp`
   [![Sanity MCP connector](https://glama.ai/mcp/connectors/io.sanity.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.sanity.www/mcp)
   🔐 - Query and mutate Sanity datasets and documents.


### PR DESCRIPTION
**Disclosure: I am the author of LetX.**

LetX is a hosted LaTeX editor. Its remote MCP server lets an assistant search templates, create projects, edit files, and compile to PDF with the real build log returned, so the model can see whether the document actually built rather than guessing.

- Endpoint: `https://api.letx.app/mcp` (Streamable HTTP)
- Auth: OAuth 2.1
- Published in the official MCP registry as [`app.letx/letx`](https://registry.modelcontextprotocol.io/v0/servers?search=letx), currently 1.1.0
- Glama connector: https://glama.ai/mcp/connectors/app.letx/letx

Placed in Content Management alphabetically between GoodBarber and Sanity, matching the existing entry format including the Glama score badge.

Filed here rather than in `awesome-mcp-servers` per its CONTRIBUTING: this server is remote-only, with no installable package.

Verifiable:

```bash
curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=letx" | python3 -m json.tool
```