### PR TITLE
Add Fi-Plan MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [CVR Lookup](https://cvrlookup.dk/mcp) `https://cvrlookup.dk/api/mcp`
   [![CVR Lookup MCP connector](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup/badges/score.svg)](https://glama.ai/mcp/connectors/dk.cvrlookup/cvr-lookup)
   🔓 - Danish company register: company lookup, name search, and annual-report financials; data tools need a free key.
+- [Fi-Plan](https://www.fi-plan.in) `https://www.fi-plan.in/mcp`
+  [![Fi-Plan MCP connector](https://glama.ai/mcp/connectors/in.fi-plan/fi-plan/badges/score.svg)](https://glama.ai/mcp/connectors/in.fi-plan/fi-plan)
+  🔓 - Financial simulator for Indian salaries: loans, taxes, SIPs, and 50-year FIRE plans.
 - [Fruit Stand](https://fruitstand.dev) `https://api.fruitstand.dev/mcp`
   [![Fruit Stand MCP connector](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns/badges/score.svg)](https://glama.ai/mcp/connectors/dev.fruitstand/fund-returns)
   🔓 - Historical return data for funds and tickers.


### PR DESCRIPTION
Adds Fi-Plan, a hosted remote MCP server for Indian personal finance.

- Homepage: https://www.fi-plan.in
- Endpoint: https://www.fi-plan.in/mcp (Streamable HTTP, anonymous)
- Glama connector: https://glama.ai/mcp/connectors/in.fi-plan/fi-plan
- Auth: none for the 4 public calculator tools; account tools optional via API token/OAuth

Tools: loan_amortization, loan_refinance, asset_projection, simulate_plan.