### PR TITLE
Add Digital Experts Hypotheses (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [DABYTE AI Visibility Index](https://dabyte.ai) `https://dabyte.ai/mcp`
   [![DABYTE MCP connector](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index/badges/score.svg)](https://glama.ai/mcp/connectors/ai.dabyte/visibility-index)
   🔓 - Weekly share of answer for 20 SaaS and AI tool brands across ChatGPT, Perplexity and Gemini, with the frozen prompt panel behind it.
+- [Digital Experts Hypotheses](https://digitalexperts.tv/data) `https://mcp.digitalexperts.tv/mcp`
+  [![Digital Experts Hypotheses MCP connector](https://glama.ai/mcp/connectors/tv.digitalexperts/hypotheses/badges/score.svg)](https://glama.ai/mcp/connectors/tv.digitalexperts/hypotheses)
+  🔓 - Open dataset of 1,590 JTBD marketing hypotheses with cold-traffic test results: cost per subscriber and per lead by niche.
 - [FoxForm](https://foxform.app) `https://mcp.foxform.app/mcp`
   [![FoxForm MCP connector](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form/badges/score.svg)](https://glama.ai/mcp/connectors/app.foxform.mcp/fox-form)
   🔓 - Build scored forms, quizzes and calculators, publish them, and read responses with per-screen analytics.


### PR DESCRIPTION
Adds **Digital Experts Hypotheses** to Marketing.

- Endpoint: `https://mcp.digitalexperts.tv/mcp` — Streamable HTTP, no authentication (🔓), rate-limited
- Glama connector: https://glama.ai/mcp/connectors/tv.digitalexperts/hypotheses (also in the official MCP Registry as `tv.digitalexperts/hypotheses`)
- What it does: read-only tools over an open dataset of 1,590 anonymised JTBD marketing hypotheses with cold-traffic test results (cost per subscriber and per lead by niche, 2019–2026), CC BY 4.0. Tools: `list_niches`, `niche_stats`, `search_hypotheses`, `get_hypothesis`, `methodology`.
- Docs: https://digitalexperts.tv/data#mcp

Opened by an automated agent on behalf of the server's maintainer (Digital Experts). The repository is starred from the maintainer's account.