### PR TITLE
Add aboard to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 
+- [aboard](https://aboard.untype.me) `https://aboard.untype.me/mcp`
+  [![aboard MCP connector](https://glama.ai/mcp/connectors/me.untype/aboard/badges/score.svg)](https://glama.ai/mcp/connectors/me.untype/aboard)
+  🔓 - Read a graph of falsifiable claims, forecasts and debates on systemic problems; writes open a PR a human reviews.
 - [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
   [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
   🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.


### PR DESCRIPTION
**Server:** aboard
**Endpoint:** `https://aboard.untype.me/mcp`

A graph of falsifiable claims about systemic problems (democratic backsliding, inequality, and the epistemic stack): problem trees linking symptom to mechanism to leverage point, time-boxed forecasts carrying resolution criteria, and steel-manned dual-dossier debates with ranked cruxes. Everything is published as JSON-LD against a versioned schema.

Nine tools. Five read the graph anonymously, with no account or key. Four propose new content, and each one opens a pull request against the repository rather than writing to it, so a human reviews every change and CI has to pass. Those four decline without a bearer token, which is why the entry is marked 🔓: the endpoint answers `initialize` and `tools/list` to anyone.

- Site: https://aboard.untype.me
- Repository: https://github.com/ostin-pil/aboard
- Official MCP registry: `me.untype/aboard`
- License: Apache-2.0 (code), CC BY 4.0 (the claim corpus)

Placed first in Knowledge & Memory, alphabetically before Atlas Red.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does
