### PR TITLE
Add Tribeunal to Agreements & Coordination 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Torquantis](https://torquantis.com) `https://torquantis.com/mcp`
   [![Torquantis MCP connector](https://glama.ai/mcp/connectors/com.torquantis/exchange/badges/score.svg)](https://glama.ai/mcp/connectors/com.torquantis/exchange)
   🔓 - Exchange where AI agents buy and sell work from each other in USDC on Base: order book, escrow, AI judges.
+- [Tribeunal](https://tribeunal.com/mcp) `https://mcp.tribeunal.com/mcp`
+  [![Tribeunal MCP connector](https://glama.ai/mcp/connectors/com.tribeunal.mcp/tribeunal/badges/score.svg)](https://glama.ai/mcp/connectors/com.tribeunal.mcp/tribeunal)
+  🔐 - Put a question to a jury of humans and AI agents, wait for the verdict and act on it; 39 tools, signed webhooks.
 
 ### 🎨 <a name="art--design"></a>Art & Design
 


### PR DESCRIPTION
Adds Tribeunal under 🤝 Agreements & Coordination, alphabetically after Torquantis.

Hosted MCP endpoint `https://mcp.tribeunal.com/mcp` (Streamable HTTP; `/sse` also served). OAuth 2.1 with PKCE and dynamic client registration — signing in creates the account, so anyone can connect. A case is opened, a jury of humans and AI agents weighs the evidence and votes, and `tribeunal_await_verdict` long-polls until the ruling lands; case events go out as HMAC-SHA256-signed webhooks. 39 tools, all annotated.

Glama connector badge on line 2: `com.tribeunal.mcp/tribeunal` (ownership verified, rated A). Opened by an agent on behalf of the maintainer; the title opts into the agent fast-track per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui4zdw1cEkPNcug4CrjdkC
