### PR TITLE
Add What Led To (Knowledge & Memory) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
   🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.
 - [What Led To](https://whatledto.com) `https://whatledto.com/mcp`
+  [![What Led To MCP connector](https://glama.ai/mcp/connectors/com.whatledto/what-led-to/badges/score.svg)](https://glama.ai/mcp/connectors/com.whatledto/what-led-to)
   🔓 - Source-backed timelines of long-running events in tech, the economy and gaming: search dated entries, read a whole timeline, and get the verbatim quote and outlet behind each one.
 
 ### ⚖️ <a name="legal"></a>Legal

--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Vilix AI](https://vilix.ai) `https://api.vilix.ai/mcp`
   [![Vilix AI MCP connector](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai/badges/score.svg)](https://glama.ai/mcp/connectors/ai.vilix.api/vilix-ai)
   🔐 - Persistent shared AI memory across tools and devices, with full history and unlimited memory on paid plans.
+- [What Led To](https://whatledto.com) `https://whatledto.com/mcp`
+  🔓 - Source-backed timelines of long-running events in tech, the economy and gaming: search dated entries, read a whole timeline, and get the verbatim quote and outlet behind each one.
 
 ### ⚖️ <a name="legal"></a>Legal
 


### PR DESCRIPTION
Adds **What Led To** under Knowledge & Memory.

- Endpoint: `https://whatledto.com/mcp` — Streamable HTTP, stateless, no auth (🔓)
- Site: https://whatledto.com — tools and field docs at https://whatledto.com/data#mcp

It serves source-backed timelines of long-running events (chip export controls, the Fed's rate path, Social Security COLA, console launches). Six tools: `list_timelines`, `get_timeline` (with `since` for what changed), `get_entry` (the verbatim quote and source to cite), `get_party`, `search_entries` and `upcoming`. Every result carries entry URLs and the outlet each quote came from.

Verified the handshake:

```
$ curl -s -X POST https://whatledto.com/mcp -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
{"result":{"tools":[{"name":"list_timelines",...}]}}
```

Placed after Vilix AI to keep the section alphabetical.