### PR TITLE
Add ausecon — Australian economic data from ABS, RBA and APRA 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [AlphaPipeline](https://alphapipeline-eu.onrender.com) `https://alphapipeline-eu.onrender.com/mcp`
   [![AlphaPipeline MCP connector](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.onrender.alphapipeline/alpha-pipeline-agent-mcp)
   🔓 - Crypto trading data for AI agents: Polymarket prediction-market arbitrage, kimchi premium alerts, on-chain token-unlock risk, token security scans, funding rates, and webpage-to-Markdown conversion; x402 pay-per-call in USDC on Base, no signup.  
+- [ausecon](https://auseconmcp.com) `https://mcp.auseconmcp.com/mcp`
+  [![ausecon MCP connector](https://glama.ai/mcp/connectors/io.github.AnthonyPuggs/ausecon-mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.AnthonyPuggs/ausecon-mcp-server)
+  🔓 - Read-only Australian economic data from ABS, RBA and APRA, including GDP, inflation and interest rates.
 - [Autoview](https://autoview.com/) `https://api.autoview.com/mcp/`
   [![Autoview MCP connector](https://glama.ai/mcp/connectors/io.github.autoview-com/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.autoview-com/mcp)
   🔓 - Trade across 22+ exchanges and brokers from any MCP-capable AI agent; dry-run by default, live trading on Kraken and Crypto.com.


### PR DESCRIPTION
**Server:** [ausecon](https://auseconmcp.com)
**Endpoint:** `https://mcp.auseconmcp.com/mcp`

Adds ausecon to Finance: a hosted, read-only MCP server providing Australian economic and financial data from ABS, RBA and APRA. It uses Streamable HTTP and requires no account or API key.

- [x] The endpoint is public and answers an MCP `initialize` request
- [x] Entry is in the correct category, in alphabetical order
- [x] Entry has its Glama connector badge on the second line
- [x] Auth marker matches what the endpoint actually does

A live smoke test on 12 September 2026 successfully completed initialisation, tool discovery, economic concept discovery and retrieval of three RBA cash-rate observations with source provenance. No authentication was supplied.

The change adds only the three-line README entry, alphabetically between AlphaPipeline and Autoview.

Thanks for the invitation to submit here in [punkpeye/awesome-mcp-servers#10965](https://github.com/punkpeye/awesome-mcp-servers/pull/10965#issuecomment-5580699566).