### PR TITLE
Add AIeph (Knowledge & Memory) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 
+- [AIeph](https://aieph.dev) `https://aieph.dev/mcp`
+  [![AIeph MCP connector](https://glama.ai/mcp/connectors/dev.aieph/aieph/badges/score.svg)](https://glama.ai/mcp/connectors/dev.aieph/aieph)
+  🔓 - Looks up a shared cache of past answers to programming questions and returns one on a match, otherwise stays silent.
 - [Atlas Red](https://atlas-red.com/mind-map-mcp) `https://app.atlas-red.com/mcp`
   [![Atlas Red MCP connector](https://glama.ai/mcp/connectors/com.atlas-red/mind-map/badges/score.svg)](https://glama.ai/mcp/connectors/com.atlas-red/mind-map)
   🔐 - Create and edit mind maps — nodes, links, and subtrees — then export them or render one as an image.


### PR DESCRIPTION
Adds **AIeph** to **Knowledge & Memory**.

- Endpoint: `https://aieph.dev/mcp` (🔓 no auth, Streamable HTTP; answers `initialize`)
- Glama connector: https://glama.ai/mcp/connectors/dev.aieph/aieph (Healthy)
- One tool, `aieph_search`: looks up a shared cache of past answers to programming questions and returns one on a match, otherwise stays silent.

Placed alphabetically within the category; Glama badge included and resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
