### PR TITLE
Add Kanxueshan — golden-hour forecasts for snow mountains in China 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Jet Tracker](https://jettracker.com.br/desenvolvedores) `https://jettracker.com.br/api/mcp`
   [![Jet Tracker MCP connector](https://glama.ai/mcp/connectors/br.com.jettracker/jet-tracker/badges/score.svg)](https://glama.ai/mcp/connectors/br.com.jettracker/jet-tracker)
   🔐 - Brazilian business aviation: each aircraft's real owner, flights, overnight base, market and maintenance signals.
+- [Kanxueshan](https://www.yilong.art) `https://www.yilong.art/mcp`
+  🔓 - Golden-hour (日照金山) sunrise/sunset visibility forecasts for snow mountains in China: 0-100 score, cloud/humidity/wind factors, viewpoints, and DEM line-of-sight checks.
 - [Korea Nationwide Data](https://korea-data-mcp.picks-site.workers.dev/) `https://korea-data-mcp.picks-site.workers.dev/mcp`
   [![Korea Nationwide Data MCP connector](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.sean-park-funda/korea-data-mcp)
   🔓 - Korean tourist attractions in Korean and English, bus stops across 138 cities, and 30-year weather normals.


### PR DESCRIPTION
Adds **Kanxueshan (看雪山)** to Travel & Transportation.

- **Endpoint**: `https://www.yilong.art/mcp` (streamable HTTP)
- **Auth**: 🔓 none — connect anonymously

Golden-hour (日照金山) sunrise/sunset visibility forecasts for ~90 snow mountains in China: golden-hour windows, a 0-100 visibility score, weather factors (cloud cover, low cloud, humidity, wind), and suggested viewpoints. The score combines Open-Meteo weather with a DEM line-of-sight check (whether a given viewpoint can actually see the summit) plus solar altitude.

Tools: `search_peak`, `query_peaks`, `forecast_peak`.

Verified the endpoint answers an MCP `initialize` handshake. Also published in the official registry as `io.github.geoxing/kanxueshan`.
