### PR TITLE
Add SimFuse to Travel & Transportation 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,10 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Roamzy MCP connector](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.roamzy-io/mcp-server)
   🔓 - Buy and manage one global eSIM for 193 countries, billed per megabyte in USDT or USDC — no account, no signup, no KYC.
 
+- [SimFuse](https://simfuse.app/agent/) `https://api.simfuse.app/agentic/mcp`
+  [![SimFuse MCP connector](https://glama.ai/mcp/connectors/app.simfuse.api/sim-fuse-e-sim-storefront/badges/score.svg)](https://glama.ai/mcp/connectors/app.simfuse.api/sim-fuse-e-sim-storefront)
+  🔓 - Travel eSIMs for 200+ countries: browse plans, check coverage, price a multi-country trip, and open a checkout.
+
 ### 🔄 <a name="version-control"></a>Version Control
 
 - [GitHub](https://github.com) `https://api.githubcopilot.com/mcp/`


### PR DESCRIPTION
SimFuse is a travel eSIM storefront. The MCP server lets an assistant browse destinations and data plans for 200+ countries, read a plan's real terms (allowance, validity, fair-use policy, hotspot, network), resolve which countries a regional plan actually covers, price a whole multi-country trip against live retail prices, and open a checkout session at frozen prices.

- Endpoint: https://api.simfuse.app/agentic/mcp
- Transport: Streamable HTTP
- Auth: none, every read tool is public
- Docs: https://simfuse.app/agent/
- Source and connection guides: https://github.com/qorinx/simfuse-mcp
- Glama connector: https://glama.ai/mcp/connectors/app.simfuse.api/sim-fuse-e-sim-storefront

The server charges nothing itself. create-checkout-session opens a session and returns a URL; payment and eSIM delivery happen on simfuse.app.
