### PR TITLE
Add TeamAgent Canvas (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Webflow MCP connector](https://glama.ai/mcp/connectors/com.webflow/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.webflow/mcp)
   🔐 - Manage Webflow sites, collections, and CMS items.
 - [Wix](https://wix.com) `https://mcp.wix.com/mcp`
+- [TeamAgent Canvas](https://github.com/AvatarGaia/canvas-mcp)  `https://agent.avatargaia.top/api/mcp/canvas`
   [![Wix MCP connector](https://glama.ai/mcp/connectors/com.wix/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.wix/mcp)
   🔐 - Manage Wix sites, business data, and bookings.
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
   [![Webflow MCP connector](https://glama.ai/mcp/connectors/com.webflow/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.webflow/mcp)
   🔐 - Manage Webflow sites, collections, and CMS items.
 - [Wix](https://wix.com) `https://mcp.wix.com/mcp`
-- [TeamAgent Canvas](https://github.com/AvatarGaia/canvas-mcp)  `https://agent.avatargaia.top/api/mcp/canvas`
   [![Wix MCP connector](https://glama.ai/mcp/connectors/com.wix/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.wix/mcp)
   🔐 - Manage Wix sites, business data, and bookings.
+- [TeamAgent Canvas](https://github.com/AvatarGaia/canvas-mcp)  `https://agent.avatargaia.top/api/mcp/canvas`
 
 ### 👤 <a name="crm"></a>CRM
 


### PR DESCRIPTION
Adds **TeamAgent Canvas MCP** ([repo](https://github.com/AvatarGaia/canvas-mcp)).

- Remote (streamable-http): `https://agent.avatargaia.top/api/mcp/canvas` (Bearer API key)
- npm stdio shim: `npx -y @avatargaia/canvas-mcp --url ... --token ...`
- Official MCP Registry: `io.github.AvatarGaia/canvas-mcp` (active)

First-party server from [AvatarGaia](https://github.com/AvatarGaia).