### PR TITLE
Add Errand (dispatch real humans in Seoul) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [BioVet](https://bio.vet/) `https://bio.vet/mcp`
   [![BioVet MCP connector](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp/badges/score.svg)](https://glama.ai/mcp/connectors/vet.bio/biovet-mcp)
   🔓 - Find a 24/7 vet clinic in Moscow, check live prices and free doctor slots, book a visit, and triage symptoms.
+- [Errand](https://errand.be) `https://errand.be/api/mcp`
+  [![Errand MCP connector](https://glama.ai/mcp/connectors/be.errand/errand/badges/score.svg)](https://glama.ai/mcp/connectors/be.errand/errand)
+  🔐 - Dispatch a real person in Seoul to check, photograph, or queue somewhere and get GPS-verified evidence back.
 - [Human Design](https://www.gethumandesign.com/mcp-docs/) `https://api.gethumandesign.com/mcp`
   [![Human Design MCP connector](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp/badges/score.svg)](https://glama.ai/mcp/connectors/com.gethumandesign.www/mcp)
   🔐 - Calculate Human Design bodygraphs from birth data, compare two people, and analyse group dynamics.


### PR DESCRIPTION
Adds **Errand** to *Other Tools & Integrations*.

- Endpoint: `https://errand.be/api/mcp` (Streamable HTTP)
- Auth: OAuth 2.1 with dynamic client registration (`/.well-known/oauth-protected-resource` → Supabase Auth), or an API key. Marked 🔐.
- Glama connector: https://glama.ai/mcp/connectors/be.errand/errand (registry-linked, healthy)
- Official registry: `be.errand/errand`
- Docs: https://errand.be/docs

What it does: an agent names a place in Seoul (Gangnam area today); a nearby person with the Errand iOS app goes there, takes photos in-app, answers the agent's questions. The server verifies GPS/capture time, an AI grades the evidence against the caller's pass criteria, and the agent gets photos + structured answers + a pass/fail. Seven tools: `errand_check_coverage`, `errand_list_capabilities`, `errand_quote`, `errand_dispatch`, `errand_get_status`, `errand_get_result`, `errand_cancel`. Only `errand_dispatch` moves money; prepaid escrow, refunded in full if the errand isn't completed.

Public sign-up at https://errand.be (email + 6-digit code). Repo starred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTvvM9Wc8wgQtjAvRGTfqB