### PR TITLE
Add SearcherLite to Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [RedReplier](https://redreplier.com) `https://mcp.redreplier.com/mcp`
   [![RedReplier MCP connector](https://glama.ai/mcp/connectors/com.redreplier/mcp-server/badges/score.svg)](https://glama.ai/mcp/connectors/com.redreplier/mcp-server)
   🔐 - Find Reddit, Hacker News, X and Bluesky posts that mention your product or keywords, scored for lead relevance.
+- [SearcherLite](https://searcherlite.com) `https://searcherlite.com/api/mcp`
+  [![SearcherLite MCP connector](https://glama.ai/mcp/connectors/com.searcherlite/searcherlite/badges/score.svg)](https://glama.ai/mcp/connectors/com.searcherlite/searcherlite)
+  🔐 - Google keyword, domain, backlink and AI-visibility data, paid per lookup in credits with no subscription.
 - [Superflow Free Tools](https://usesuperflow.ai/tools) `https://usesuperflow.ai/api/mcp`
   [![Superflow Free Tools MCP connector](https://glama.ai/mcp/connectors/ai.usesuperflow/tools/badges/score.svg)](https://glama.ai/mcp/connectors/ai.usesuperflow/tools)
   🔓 - Free website QA and AI-visibility tools: AI crawlability, robots.txt vs AI crawlers, llms.txt, JSON-LD, social previews, screenshots, and more. No account, no API key.


### PR DESCRIPTION
Adds SearcherLite, a remote MCP server for SEO data, under Marketing.

- Endpoint: `https://searcherlite.com/api/mcp` (Streamable HTTP, stateless)
- Auth: OAuth 2.1 with dynamic client registration (returns `401` + `WWW-Authenticate` with `resource_metadata`); API keys also accepted for clients without OAuth
- Glama connector: https://glama.ai/mcp/connectors/com.searcherlite/searcherlite (ownership verified, healthy)
- 27 tools: Google keyword overview, SERP, related keywords, suggestions, questions, bulk keyword metrics, domain overview/keywords/pages/competitors/compare, backlinks overview/list/referring domains/anchors/pages/competitors/compare, AI visibility overview/trend/compare/prompts/pages/sources/check (Google AI Overviews, AI Mode, ChatGPT)
- Data source: DataForSEO. Paid per lookup in credits, no subscription; public sign-up with 20 free credits, no card
- Maintainer: SearcherLite (first party), docs at https://searcherlite.com/mcp

Example usage: "What is the search volume and difficulty for 'varmepumpe' in Denmark?" or "Which pages on example.com does Google AI Overview cite, and for which prompts?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
