### PR TITLE
Add AbaPay 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 
 ### 💳 <a name="payments"></a>Payments
 
+- [AbaPay](https://abapays.com) `https://www.abapays.com/api/mcp`
+  🔐 - Pay real-world bills (airtime, data, electricity, cable, education, 170+ country international top-ups) with stablecoins on Celo and Base — check balance, pay, batch up to 20 recipients, or schedule recurring spend, settled on-chain.
 - [Dodo Payments](https://dodopayments.com) `https://mcp.dodopayments.com/mcp`
   🔐 - Manage Dodo Payments products, subscriptions, and payouts.
 - [Paddle](https://paddle.com) `https://mcp.paddle.com/mcp`


### PR DESCRIPTION
Adds AbaPay to the Payments section — a remote MCP server (Streamable HTTP at `https://www.abapays.com/api/mcp`) for stablecoin bill-pay on Celo and Base: airtime, data, electricity, cable, education, and international top-ups in 170+ countries, settled on-chain.

Repo: https://github.com/investorphem/AbaPay (public, MIT). Also listed in the official MCP Registry as `io.github.investorphem/abapay`.