### PR TITLE
Add Emboss 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,9 @@ Entries with a [Glama connector](https://glama.ai/mcp/connectors) badge have bee
 - [Document Player](https://documentplayer.com/connect-ai/) `https://documentplayer.com/mcp`
   [![Document Player MCP connector](https://glama.ai/mcp/connectors/com.documentplayer/document-player/badges/score.svg)](https://glama.ai/mcp/connectors/com.documentplayer/document-player)
   🔐 - Send text from your AI to a reader window to read along and listen, with playback controls for each sentence.
+- [Emboss](https://getemboss.ai) `https://api.getemboss.ai/mcp`
+  [![Emboss MCP connector](https://glama.ai/mcp/connectors/io.github.edwinorange/emboss/badges/score.svg)](https://glama.ai/mcp/connectors/io.github.edwinorange/emboss)
+  🔐 - Makes PDF forms fillable, fills them from data or documents, reads them back, and faxes the result.
 - [Fireflies](https://fireflies.ai) `https://api.fireflies.ai/mcp`
   [![Fireflies MCP connector](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly/badges/score.svg)](https://glama.ai/mcp/connectors/ai.fireflies.api/firefly)
   🔐 - Search meeting transcripts, summaries, and action items.


### PR DESCRIPTION
Emboss is a hosted MCP server (Streamable HTTP, OAuth 2.1 with dynamic client registration, public sign-up) that turns any PDF form into a fillable one, fills it from data or supporting documents, reads a filled form back, and faxes the result to any fax number.

- Endpoint: https://api.getemboss.ai/mcp
- Docs: https://getemboss.ai/docs/mcp-tools
- Glama connector: https://glama.ai/mcp/connectors/io.github.edwinorange/emboss
- Category: Workplace & Productivity, alphabetical position kept.

Opened by an automated agent on behalf of the maintainer, per the CONTRIBUTING note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fam8AgQ94zGZze8w4zdzdP